### PR TITLE
feat: redirect to user path if user is logged in

### DIFF
--- a/app/controllers/charges_controller.rb
+++ b/app/controllers/charges_controller.rb
@@ -29,8 +29,11 @@ class ChargesController < ApplicationController
 
     if donation.save!
       notice = "Thank you for donating #{displayable_amount(@amount)}."
-      redirect_to user_path(current_user), notice: notice if current_user
-      redirect_to root_path, notice: notice
+      if current_user
+        redirect_to user_path(current_user), notice: notice
+      else
+        redirect_to root_path, notice: notice
+      end
     else
       redirect_to new_charge_path
     end

--- a/app/controllers/charges_controller.rb
+++ b/app/controllers/charges_controller.rb
@@ -28,7 +28,9 @@ class ChargesController < ApplicationController
     donation.user_id = @user.id if @user
 
     if donation.save!
-      redirect_to root_path, notice: "Thank you for donating #{displayable_amount(@amount)}."
+      notice = "Thank you for donating #{displayable_amount(@amount)}."
+      redirect_to user_path(current_user), notice: notice if current_user
+      redirect_to root_path, notice: notice
     else
       redirect_to new_charge_path
     end

--- a/app/views/charges/new.html.erb
+++ b/app/views/charges/new.html.erb
@@ -34,7 +34,6 @@
       <script src="https://checkout.stripe.com/checkout.js" class="stripe-button"
               data-key="<%= ENV['STRIPE_PUBLISHABLE_KEY'] %>"
               data-description="One time donation"
-              data-amount="100"
               data-locale="auto"></script>
     <% end %>
     </section>

--- a/app/views/charges/new.html.erb
+++ b/app/views/charges/new.html.erb
@@ -1,36 +1,42 @@
-<h1>Donate today</h1>
-
-<div id="one-time-donation">
-  <%= form_with(model: Donation, url: charges_path) do |form| %>
-    <div>
-      <% if flash[:error].present? %>
-        <div id="error_explanation">
-          <p><%= flash[:error] %></p>
+<div id="checkout" class="one-time-donation">
+  <div class="content">
+    <section id="checkout-plan">
+      <h4>Pay what you can. Every dollar counts.</h4>
+      <p>“To each according to their ability, to each according to their need.” Contributing what you can, where you can is what we’re all about.</p>
+      <p>Folks who donate $100 on a one-time basis will receive a free gift from our store. People who pay dues at the rate of $100 per month or more will receive a thank you call from us.</p>
+    </section>
+    <section id='checkout-payment'>
+    <%= form_with(model: Donation, url: charges_path) do |form| %>
+      <div>
+        <% if flash[:error].present? %>
+          <div id="error_explanation">
+            <p><%= flash[:error] %></p>
+          </div>
+        <% end %>
+        <div class="field">
+          <%= form.label :amount %>
+          <%= form.number_field :amount, step: 'any', min: 1, id: 'donation-amount', placeholder: '$1' %>
         </div>
-      <% end %>
-      <div class="field">
-        <%= form.label :amount %>
-        <%= form.number_field :amount, step: 'any', min: 1, id: 'donation-amount', value: 1 %>
       </div>
-    </div>
 
-    <script>
-      const amountInput = document.getElementById('donation-amount');
+      <script>
+        const amountInput = document.getElementById('donation-amount');
 
-      function setStripeCheckoutAmount(e) {
-        const amount = amountInput.value
-        const tag = document.getElementsByClassName('stripe-button')[0];
-        console.log(tag, amount)
-        tag.dataset.amount = amount * 100; // amount in cents
-      }
+        function setStripeCheckoutAmount(e) {
+          const amount = amountInput.value
+          const tag = document.getElementsByClassName('stripe-button')[0];
+          tag.dataset.amount = amount * 100; // amount in cents
+        }
 
-      amountInput.addEventListener('input', setStripeCheckoutAmount)
-    </script>
+        amountInput.addEventListener('input', setStripeCheckoutAmount)
+      </script>
 
-    <script src="https://checkout.stripe.com/checkout.js" class="stripe-button"
-            data-key="<%= ENV['STRIPE_PUBLISHABLE_KEY'] %>"
-            data-description="One time donation"
-            data-amount="100"
-            data-locale="auto"></script>
-  <% end %>
+      <script src="https://checkout.stripe.com/checkout.js" class="stripe-button"
+              data-key="<%= ENV['STRIPE_PUBLISHABLE_KEY'] %>"
+              data-description="One time donation"
+              data-amount="100"
+              data-locale="auto"></script>
+    <% end %>
+    </section>
+  </div>
 </div>

--- a/app/views/static_pages/home.html.erb
+++ b/app/views/static_pages/home.html.erb
@@ -39,7 +39,7 @@
           </h3>
           <h4><%= plan.headline %></h4>
           <%= plan.description %>
-          <p><%= link_to 'Subscribe', new_subscription_charge_path(plan_id: plan) %></p>
+          <p><%= link_to 'Subscribe', @current_user ? new_subscription_charge_path(plan_id: plan) : login_path  %></p>
         </div>
       <% end %>
       <div class="subscription--plan" id="one-time-donation">

--- a/spec/features/donations_spec.rb
+++ b/spec/features/donations_spec.rb
@@ -10,9 +10,9 @@ describe 'Donations', type: :feature do
 
       click_link 'Make a donation today'
 
-      expect(page).to have_content('Donate today')
+      expect(page).to have_content('Pay what you can. Every dollar counts.')
 
-      within '#one-time-donation' do
+      within '.one-time-donation' do
         fill_in 'donation-amount', with: 25
         # TODO: add stripe elements expectations
         # click_button 'Pay with Card'

--- a/spec/features/donations_spec.rb
+++ b/spec/features/donations_spec.rb
@@ -3,9 +3,13 @@
 require 'rails_helper'
 
 describe 'Donations', type: :feature do
-  context 'as an anonymous user' do
+  context 'as user', js: true do
+    let!(:user) { FactoryBot.create(:user, stripe_id: nil) }
+
     it 'allows going through the flow and prompts for a user account creation' do
+      allow_any_instance_of(SessionProvider).to receive(:current_user).and_return(user)
       visit '/'
+      expect(page).to_not have_content('Log In') # checking user is logged in
       expect(page).to have_content('Pay what you can')
 
       click_link 'Make a donation today'
@@ -14,11 +18,9 @@ describe 'Donations', type: :feature do
 
       within '.one-time-donation' do
         fill_in 'donation-amount', with: 25
-        # TODO: add stripe elements expectations
-        # click_button 'Pay with Card'
+        click_button 'Pay with Card'
+        # can't access elements inside iframe within capybara
       end
-
-      # expect(page).to have_content('Subscription was successfully added.')
     end
   end
 end


### PR DESCRIPTION
**What:** User should be able to do a one-time donation

Why: We want users to either get a membership (recurring donations) or donate once. These donations should appear in the dashboard and contribute to their donated total.
Closes #10 

**How:**
Adding a redirection to logged-in users when a one-time donation is done.

## Screenshots
<img width="1980" alt="image" src="https://user-images.githubusercontent.com/1833858/66327448-23807f00-e92b-11e9-8d57-3a43fcf653e3.png">
