### PR TITLE
Add health_check endpoint for ELB check

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,6 +43,8 @@ gem 'bootsnap', '>= 1.4.2', require: false
 gem 'sidekiq', '~> 6.0'
 gem 'sidekiq-scheduler', '~> 3.0'
 
+gem "health_check", github: 'ianheggie/health_check', :ref => '0b799ea'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,12 @@
 GIT
+  remote: https://github.com/ianheggie/health_check.git
+  revision: 0b799ead604f900ed50685e9b2d469cd2befba5b
+  ref: 0b799ea
+  specs:
+    health_check (4.0.0.pre)
+      rails (>= 4.0)
+
+GIT
   remote: https://github.com/rspec/rspec-core
   revision: 4ab682260afe252b90c4330bb7f91430f68f68c4
   specs:
@@ -344,6 +352,7 @@ DEPENDENCIES
   factory_bot_rails (~> 5.0, >= 5.0.2)
   faker (~> 2.1, >= 2.1.2)
   ffi (~> 1.9, >= 1.9.25)
+  health_check!
   jbuilder (~> 2.7)
   jwt (~> 2.2.1)
   listen (>= 3.0.5, < 3.3)

--- a/config/application.rb
+++ b/config/application.rb
@@ -44,6 +44,11 @@ module Fundraising
     end
 
     config.active_job.queue_adapter = :sidekiq
-    Sidekiq.configure_server { |c| c.redis = { url: ENV['REDIS_URL'], namespace: "sidekiq_#{Rails.application.class.module_parent_name}_#{Rails.env}".downcase } }
+    Sidekiq.configure_server do |c|
+      c.redis = {
+        url: ENV['REDIS_URL'],
+        namespace: "sidekiq_#{Rails.application.class.module_parent_name}_#{Rails.env}".downcase
+      }
+    end
   end
 end

--- a/config/initializers/health_check.rb
+++ b/config/initializers/health_check.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+HealthCheck.setup do |config|
+  config.uri = 'health-check'
+  config.success = 'success'
+  config.http_status_for_error_text = 500
+  config.http_status_for_error_object = 500
+
+  # You can customize which checks happen on a standard health check, eg to set an explicit list use:
+  config.standard_checks = %w[database migrations custom]
+
+  # You can set what tests are run with the 'full' or 'all' parameter
+  config.full_checks = %w[database migrations custom email cache redis resque-redis sidekiq-redis s3]
+
+  # http status code used when the ip is not allowed for the request
+  config.http_status_for_ip_whitelist_error = 403
+
+  # Disable the error message to prevent /health_check from leaking
+  # sensitive information
+  config.include_error_in_response_body = false
+end

--- a/scripts/ecs_db_migrate.rb
+++ b/scripts/ecs_db_migrate.rb
@@ -18,7 +18,8 @@ end
 overrides = {
   containerOverrides: [{
     name: container,
-    command: ['bundle', 'exec', 'rake', 'db:migrate']
+    memoryReservation: 256,
+    command: ['bundle', 'exec', 'rails', 'db:migrate']
   }]
 }
 


### PR DESCRIPTION
**What:** Add health_check endpoint for ELB check

**Why:** To have an endpoint that shows the status of the app to be used for ELB checks.

**How:**

- Add https://github.com/ianheggie/health_check gem and configure it

## Notes

Here's the related commit in the infra repo https://github.com/debtcollective/infra/commit/6399a22fa87f373c9d42b0f50f309374d008a695