### PR TITLE
add full login/signup url to env variables

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -3,4 +3,5 @@ STRIPE_PUBLISHABLE_KEY=STRIPE_PUBLISHABLE_KEY
 SSO_JWT_SECRET=jwt-secret
 SSO_COOKIE_NAME=tdc_auth_token
 DEV_HOST=fundraising.lvh.me
-DISCOURSE_URL=http://lvh.me:3000
+DISCOURSE_LOGIN_URL=http://lvh.me:3000/session/sso_cookies
+DISCOURSE_SIGNUP_URL=http://lvh.me:3000/session/sso_cookies/signup

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -3,19 +3,19 @@
 class SessionsController < ApplicationController
   def login
     query_string = redirect_params.to_query
-    url = "#{ENV['DISCOURSE_URL']}/session/sso_provider?#{query_string}"
+    url = "#{ENV['DISCOURSE_LOGIN_URL']}?#{query_string}"
 
     redirect_to url
   end
 
   def signup
     query_string = redirect_params.to_query
-    url = "#{ENV['DISCOURSE_URL']}/session/sso_provider/signup?#{query_string}"
+    url = "#{ENV['DISCOURSE_SIGNUP_URL']}?#{query_string}"
 
     redirect_to url
   end
 
   def redirect_params
-    params.permit(:return_url).merge(return_url: root_url)
+    params.permit(:return_url).reverse_merge(return_url: root_url)
   end
 end


### PR DESCRIPTION
**What:** add full login/signup url to env variables

**Why:** To have full control when configuring login/signup endpoints.

Related to https://github.com/debtcollective/discourse-debtcollective-sso/pull/4

**How:**

- Fix default param for return_url
- Use DISCOURSE_LOGIN_URL and DISCOURSE_SIGNUP_URL in favor of DISCOURSE_URL
