### PR TITLE
Feat/subscription toggling

### DIFF
--- a/app/controllers/plan_changes_controller.rb
+++ b/app/controllers/plan_changes_controller.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+class PlanChangesController < ApplicationController
+  before_action :set_current_user_plan, only: %i[index create]
+
+  # GET /plan_change
+  def index
+    redirect_to root_path unless current_user&.active_subscription
+  end
+
+  # GET /plan_change/new
+  def new
+    @plan_change = UserPlanChange.new
+  end
+
+  # POST /plan_change/new
+  def create
+    @plan = UserPlanChange.new(user_id: current_user.id, old_plan_id: @current_plan.id, new_plan_id: plan_params[:plan_id])
+
+    respond_to do |format|
+      if @plan.save
+        format.html { redirect_to users_path(current_user), notice: 'Plan was successfully updated.' }
+      else
+        format.html { render :new }
+      end
+    end
+  end
+
+  private
+
+  # Use callbacks to share common setup or constraints between actions.
+  def set_current_user_plan
+    @current_plan = current_user&.active_subscription
+  end
+
+  def plan_change_params
+    params.require(:plan_change).permit(:plan_id)
+  end
+end

--- a/app/controllers/plan_changes_controller.rb
+++ b/app/controllers/plan_changes_controller.rb
@@ -3,25 +3,31 @@
 class PlanChangesController < ApplicationController
   before_action :set_current_user_plan, only: %i[index create]
 
-  # GET /plan_change
+  # GET /users/:user_id/plan_change
   def index
     redirect_to root_path unless current_user&.active_subscription
+    @user = current_user
+    @plans = Plan.all
   end
 
-  # GET /plan_change/new
+  # GET /users/:user_id/plan_change/new
+  # GET /users/:user_id/plan_change/new.json
   def new
     @plan_change = UserPlanChange.new
   end
 
-  # POST /plan_change/new
+  # POST /users/:user_id/plan_change
+  # POST /users/:user_id/plan_change.json
   def create
-    @plan = UserPlanChange.new(user_id: current_user.id, old_plan_id: @current_plan.id, new_plan_id: plan_params[:plan_id])
+    head :not_authorized unless current_user
+
+    @plan = UserPlanChange.new(user_id: plan_change_params[:user_id], old_plan_id: plan_change_params[:old_plan_id], new_plan_id: plan_change_params[:new_plan_id])
 
     respond_to do |format|
       if @plan.save
-        format.html { redirect_to users_path(current_user), notice: 'Plan was successfully updated.' }
+        format.json { render json: @plan, status: :ok }
       else
-        format.html { render :new }
+        format.html { render :index }
       end
     end
   end
@@ -34,6 +40,6 @@ class PlanChangesController < ApplicationController
   end
 
   def plan_change_params
-    params.require(:plan_change).permit(:plan_id)
+    params.require(:plan_change).permit(:user_id, :old_plan_id, :new_plan_id)
   end
 end

--- a/app/controllers/plan_changes_controller.rb
+++ b/app/controllers/plan_changes_controller.rb
@@ -2,6 +2,7 @@
 
 class PlanChangesController < ApplicationController
   before_action :set_current_user_plan, only: %i[index create]
+  before_action :not_authorized_user, only: %i[create]
 
   # GET /users/:user_id/plan_change
   def index
@@ -19,8 +20,6 @@ class PlanChangesController < ApplicationController
   # POST /users/:user_id/plan_change
   # POST /users/:user_id/plan_change.json
   def create
-    head :not_authorized unless current_user
-
     @plan = UserPlanChange.new(user_id: plan_change_params[:user_id], old_plan_id: plan_change_params[:old_plan_id], new_plan_id: plan_change_params[:new_plan_id], status: 'pending')
 
     respond_to do |format|
@@ -34,7 +33,10 @@ class PlanChangesController < ApplicationController
 
   private
 
-  # Use callbacks to share common setup or constraints between actions.
+  def not_authorized_user
+    head :not_authorized unless current_user
+  end
+
   def set_current_user_plan
     @current_plan = current_user&.active_subscription
   end

--- a/app/controllers/plan_changes_controller.rb
+++ b/app/controllers/plan_changes_controller.rb
@@ -21,7 +21,7 @@ class PlanChangesController < ApplicationController
   def create
     head :not_authorized unless current_user
 
-    @plan = UserPlanChange.new(user_id: plan_change_params[:user_id], old_plan_id: plan_change_params[:old_plan_id], new_plan_id: plan_change_params[:new_plan_id])
+    @plan = UserPlanChange.new(user_id: plan_change_params[:user_id], old_plan_id: plan_change_params[:old_plan_id], new_plan_id: plan_change_params[:new_plan_id], status: 'pending')
 
     respond_to do |format|
       if @plan.save

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -7,7 +7,7 @@ class UsersController < ApplicationController
   # GET /users/1.json
   def show
     redirect_to root_path unless current_user == @user
-    @is_subscription_changing = UserPlanChange.where(user_id: @user.id).first
+    @is_subscription_changing = UserPlanChange.where(user_id: @user.id, status: 'pending').first
   end
 
   private

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -7,6 +7,7 @@ class UsersController < ApplicationController
   # GET /users/1.json
   def show
     redirect_to root_path unless current_user == @user
+    @is_subscription_changing = UserPlanChange.where(user_id: @user.id).first
   end
 
   private

--- a/app/javascript/bundles/User/components/CurrentPlan.jsx
+++ b/app/javascript/bundles/User/components/CurrentPlan.jsx
@@ -70,7 +70,7 @@ function CurrentPlanView ({ user, activePlan, plans }) {
         }
 
         return (
-          <Paper className={classes.root} key={plan.id}>
+          <Paper className={classes.root} key={plan.id} id={`plan-${plan.id}`}>
             <h4>{plan.name}</h4>
             <p>Price: {numeral(plan.amount).format('$0,0.00')}</p>
             <p dangerouslySetInnerHTML={createMarkup()} />

--- a/app/javascript/bundles/User/components/CurrentPlan.jsx
+++ b/app/javascript/bundles/User/components/CurrentPlan.jsx
@@ -1,0 +1,92 @@
+import React, { useState } from 'react'
+import numeral from 'numeral'
+import { makeStyles } from '@material-ui/core/styles'
+import Button from '@material-ui/core/Button'
+import Paper from '@material-ui/core/Paper'
+
+const useStyles = makeStyles(theme => ({
+  root: {
+    width: '100%',
+    marginTop: theme.spacing(3),
+    padding: theme.spacing(4),
+    overflowX: 'auto'
+  },
+  table: {
+    minWidth: 650
+  }
+}))
+
+const CHANGE_PLAN_ENDPOINT = id => `/users/${id}/plan_changes`
+
+function CurrentPlanView ({ user, activePlan, plans }) {
+  const classes = useStyles()
+  const [changedPlan, setPlanChanged] = useState(false)
+
+  const changePlan = async selectedPlanId => {
+    try {
+      await fetch(CHANGE_PLAN_ENDPOINT(user.id), {
+        method: 'post',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({
+          plan_change: {
+            user_id: user.id,
+            old_plan_id: activePlan.id,
+            new_plan_id: selectedPlanId
+          }
+        })
+      })
+      setPlanChanged(true)
+    } catch (error) {
+      console.error(error) // TODO: Replace with sentry
+    }
+  }
+
+  return (
+    <>
+      <Paper className={classes.root}>
+        <h3>Change your susbcription</h3>
+        <p>
+          The plan you're using to contribute is{' '}
+          <strong> {activePlan.name}</strong>.
+        </p>
+      </Paper>
+      <br />
+      <h2>Available plans</h2>
+      <p>You can change your current plan for another one at anytime.</p>
+      {changedPlan && (
+        <p className='notice--subscription'>
+          We have changed your subscription successfully.
+        </p>
+      )}
+      {plans.map(plan => {
+        function createMarkup () {
+          return { __html: plan.description.body }
+        }
+
+        function changeHandler () {
+          return changePlan(plan.id)
+        }
+
+        return (
+          <Paper className={classes.root} key={plan.id}>
+            <h4>{plan.name}</h4>
+            <p>Price: {numeral(plan.amount).format('$0,0.00')}</p>
+            <p dangerouslySetInnerHTML={createMarkup()} />
+            <Button
+              variant='contained'
+              color='primary'
+              disabled={activePlan.id === plan.id || changedPlan}
+              onClick={changeHandler}
+            >
+              Pick plan
+            </Button>
+          </Paper>
+        )
+      })}
+    </>
+  )
+}
+
+export const CurrentPlan = props => <CurrentPlanView {...props} />

--- a/app/javascript/bundles/User/components/DonationsHistory.jsx
+++ b/app/javascript/bundles/User/components/DonationsHistory.jsx
@@ -40,11 +40,6 @@ function DonationsView ({ activePlan, donations }) {
   return (
     <Paper className={classes.root}>
       <h3>Your Donations History</h3>
-      {activePlan && (
-        <p>
-          You're <strong>currently subscribed to {activePlan.name}</strong>.
-        </p>
-      )}
       <p>
         You have donated:{' '}
         <strong>{numeral(donatedAmount).format('$0,0.00')}</strong>
@@ -90,7 +85,6 @@ function DonationsView ({ activePlan, donations }) {
 }
 
 DonationsView.propTypes = {
-  activePlan: PropTypes.object,
   donations: PropTypes.array
 }
 

--- a/app/javascript/bundles/User/components/SubscriptionCancel.jsx
+++ b/app/javascript/bundles/User/components/SubscriptionCancel.jsx
@@ -1,14 +1,29 @@
 import React, { useState } from 'react'
+import { makeStyles } from '@material-ui/core/styles'
 import Button from '@material-ui/core/Button'
 import Dialog from '@material-ui/core/Dialog'
 import DialogActions from '@material-ui/core/DialogActions'
 import DialogContent from '@material-ui/core/DialogContent'
 import DialogContentText from '@material-ui/core/DialogContentText'
 import DialogTitle from '@material-ui/core/DialogTitle'
+import Paper from '@material-ui/core/Paper'
 
 const SUBSCRIPTION_CANCEL_URL = userID => `/users/${userID}/subscription`
 
-function SubscriptionCancelView ({ user, subscription }) {
+const useStyles = makeStyles(theme => ({
+  root: {
+    width: '100%',
+    marginTop: theme.spacing(3),
+    padding: theme.spacing(4),
+    overflowX: 'auto'
+  },
+  table: {
+    minWidth: 650
+  }
+}))
+
+function SubscriptionCancelView ({ user, subscription, activePlan }) {
+  const classes = useStyles()
   const [open, setOpen] = useState(false)
   const [active, toggleActive] = useState(subscription.active)
 
@@ -38,10 +53,24 @@ function SubscriptionCancelView ({ user, subscription }) {
   }
 
   return (
-    <div>
-      <Button color='secondary' onClick={handleClickOpen}>
-        Cancel Subscription
-      </Button>
+    <>
+      <Paper className={classes.root}>
+        <h3>You're subscribed</h3>
+        <p>
+          The plan you're using to contribute is{' '}
+          <strong> {activePlan.name}</strong>.
+        </p>
+        <Button
+          component='a'
+          href={`/users/${user.id}/plan_changes`}
+          color='primary'
+        >
+          Change Subscription
+        </Button>
+        <Button color='secondary' onClick={handleClickOpen}>
+          Cancel Subscription
+        </Button>
+      </Paper>
       {!active && 'No active subscription'}
       <Dialog
         open={open}
@@ -72,7 +101,7 @@ function SubscriptionCancelView ({ user, subscription }) {
           </Button>
         </DialogActions>
       </Dialog>
-    </div>
+    </>
   )
 }
 

--- a/app/javascript/bundles/User/components/SubscriptionCancel.jsx
+++ b/app/javascript/bundles/User/components/SubscriptionCancel.jsx
@@ -22,7 +22,12 @@ const useStyles = makeStyles(theme => ({
   }
 }))
 
-function SubscriptionCancelView ({ user, subscription, activePlan }) {
+function SubscriptionCancelView ({
+  user,
+  subscription,
+  activePlan,
+  isSubscriptionChanging
+}) {
   const classes = useStyles()
   const [open, setOpen] = useState(false)
   const [active, toggleActive] = useState(subscription.active)
@@ -60,13 +65,15 @@ function SubscriptionCancelView ({ user, subscription, activePlan }) {
           The plan you're using to contribute is{' '}
           <strong> {activePlan.name}</strong>.
         </p>
-        <Button
-          component='a'
-          href={`/users/${user.id}/plan_changes`}
-          color='primary'
-        >
-          Change Subscription
-        </Button>
+        {!isSubscriptionChanging && (
+          <Button
+            component='a'
+            href={`/users/${user.id}/plan_changes`}
+            color='primary'
+          >
+            Change Subscription
+          </Button>
+        )}
         <Button color='secondary' onClick={handleClickOpen}>
           Cancel Subscription
         </Button>

--- a/app/javascript/bundles/User/components/UserShow.jsx
+++ b/app/javascript/bundles/User/components/UserShow.jsx
@@ -22,7 +22,7 @@ function UserShowView ({ user, subscription, streak }) {
           You have been subscribed for {streak}
         </p>
       )}
-      <Paper className={classes.root}>
+      <Paper className={classes.root} id='contact-data'>
         <h3>Contact Data</h3>
         <p>
           <strong>Name:</strong>

--- a/app/javascript/packs/user-bundle.js
+++ b/app/javascript/packs/user-bundle.js
@@ -3,9 +3,11 @@ import ReactOnRails from 'react-on-rails'
 import { UserShow } from '../bundles/User/components/UserShow'
 import { DonationsHistory } from '../bundles/User/components/DonationsHistory'
 import { SubscriptionCancel } from '../bundles/User/components/SubscriptionCancel'
+import { CurrentPlan } from '../bundles/User/components/CurrentPlan'
 
 ReactOnRails.register({
   UserShow,
   DonationsHistory,
-  SubscriptionCancel
+  SubscriptionCancel,
+  CurrentPlan
 })

--- a/app/jobs/change_subscription_plans_job.rb
+++ b/app/jobs/change_subscription_plans_job.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class ChangeSubscriptionPlansJob < ApplicationJob
+  queue_as :default
+
+  def perform
+    pending_user_plan_changes = UserPlanChange.where(status: 'pending')
+    pending_user_plan_changes.each do |pending_user_plan_change|
+      ToggleUserActiveSubscriptionPlanJob.perform_later(pending_user_plan_change)
+    end
+  end
+end

--- a/app/jobs/toggle_user_active_subscription_plan_job.rb
+++ b/app/jobs/toggle_user_active_subscription_plan_job.rb
@@ -9,18 +9,20 @@ class ToggleUserActiveSubscriptionPlanJob < ApplicationJob
 
     # disable current user subscription.
     old_subscription = user.active_subscription
-    old_subscription.update(active: false)
+    ActiveRecord::Base.transaction do
+      old_subscription.update(active: false)
 
-    # creates a new subscription with the new plan details.
-    new_subscription = Subscription.new(
-      user_id: user_plan_change.user_id,
-      plan_id: user_plan_change.new_plan_id,
-      last_charge_at: old_subscription.last_charge_at,
-      active: true
-    )
+      # creates a new subscription with the new plan details.
+      new_subscription = Subscription.new(
+        user_id: user_plan_change.user_id,
+        plan_id: user_plan_change.new_plan_id,
+        last_charge_at: old_subscription.last_charge_at,
+        active: true
+      )
 
-    if new_subscription.save
-      UserPlanChange.find(user_plan_change.id).update(status: 'finished')
+      if new_subscription.save
+        UserPlanChange.find(user_plan_change.id).update(status: 'finished')
+      end
     end
   end
 end

--- a/app/jobs/toggle_user_active_subscription_plan_job.rb
+++ b/app/jobs/toggle_user_active_subscription_plan_job.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+class ToggleUserActiveSubscriptionPlanJob < ApplicationJob
+  queue_as :default
+
+  def perform(user_plan_change)
+    # find the user
+    user = User.find(user_plan_change.user_id)
+
+    # disable current user subscription.
+    old_subscription = user.active_subscription
+    old_subscription.update(active: false)
+
+    # creates a new subscription with the new plan details.
+    new_subscription = Subscription.new(
+      user_id: user_plan_change.user_id,
+      plan_id: user_plan_change.new_plan_id,
+      last_charge_at: old_subscription.last_charge_at,
+      active: true
+    )
+
+    if new_subscription.save
+      UserPlanChange.find(user_plan_change.id).update(status: 'finished')
+    end
+  end
+end

--- a/app/models/user_plan_change.rb
+++ b/app/models/user_plan_change.rb
@@ -3,6 +3,8 @@
 class UserPlanChange < ApplicationRecord
   belongs_to :user
 
+  enum status: %i[finished pending archived failed]
+
   validates :old_plan_id, :new_plan_id, :user_id, presence: true
   validates :user_id, uniqueness: true
 end

--- a/app/models/user_plan_change.rb
+++ b/app/models/user_plan_change.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class UserPlanChange < ApplicationRecord
+  belongs_to :user
+
+  validates :old_plan_id, :new_plan_id, :user_id, presence: true
+  validates :user_id, uniqueness: true
+end

--- a/app/views/plan_changes/index.html.erb
+++ b/app/views/plan_changes/index.html.erb
@@ -1,0 +1,3 @@
+<section class="section-content">
+  <%= react_component("CurrentPlan", props: {user: @user, activePlan: @user.active_subscription&.plan, plans: @plans}) %>
+</section>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -2,6 +2,6 @@
   <p id="notice"><%= notice %></p>
 
   <%= react_component("UserShow", props: {user: @user, streak: @user.current_streak, subscription: @user.active_subscription}) %>
-  <%= react_component("SubscriptionCancel", props: {user: @user, subscription: @user.active_subscription, activePlan: @user.active_subscription&.plan}) %>
+  <%= react_component("SubscriptionCancel", props: {user: @user, subscription: @user.active_subscription, activePlan: @user.active_subscription&.plan, isSubscriptionChanging: @is_subscription_changing}) %>
   <%= react_component("DonationsHistory", props: {donations: @user.donations}) %>
 </section>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -2,6 +2,6 @@
   <p id="notice"><%= notice %></p>
 
   <%= react_component("UserShow", props: {user: @user, streak: @user.current_streak, subscription: @user.active_subscription}) %>
-  <%= react_component("DonationsHistory", props: {activePlan: @user.active_subscription&.plan, donations: @user.donations}) %>
-  <%= react_component("SubscriptionCancel", props: {user: @user, subscription: @user.active_subscription}) %>
+  <%= react_component("SubscriptionCancel", props: {user: @user, subscription: @user.active_subscription, activePlan: @user.active_subscription&.plan}) %>
+  <%= react_component("DonationsHistory", props: {donations: @user.donations}) %>
 </section>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,6 +22,7 @@ Rails.application.routes.draw do
     resource :streak, only: %i[show]
     resources :cards, only: %i[index destroy]
     resource :subscription, only: %i[destroy]
+    resources :plan_changes, only: %i[index new create]
   end
 
   get '/login' => 'sessions#login'

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -8,3 +8,8 @@
     queue: default
     class: FindOverdueSubscriptionsJob
     description: 'This job finds all active overdue subscriptions and creates a sidekiq job to charge the subscriber'
+  find_subscription_plan_changes:
+    every: '45m'
+    queue: default
+    class: ChangeSubscriptionPlansJob
+    description: 'This job finds all pending subscription changes and creates a sidekiq job to perform the plan change'

--- a/db/migrate/20191017102956_add_subscription_change.rb
+++ b/db/migrate/20191017102956_add_subscription_change.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class AddSubscriptionChange < ActiveRecord::Migration[6.0]
+  def change
+    create_table :user_plan_changes, id: :uuid do |t|
+      t.string :old_plan_id
+      t.string :new_plan_id
+      t.string :user_id
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20191018102113_add_status_to_plan_change.rb
+++ b/db/migrate/20191018102113_add_status_to_plan_change.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddStatusToPlanChange < ActiveRecord::Migration[6.0]
+  def change
+    add_column :user_plan_changes, :status, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_09_30_093321) do
+ActiveRecord::Schema.define(version: 2019_10_17_102956) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -103,6 +103,14 @@ ActiveRecord::Schema.define(version: 2019_09_30_093321) do
     t.index ["plan_id"], name: "index_subscriptions_on_plan_id"
     t.index ["user_id", "plan_id", "active"], name: "index_subscriptions_on_user_id_and_plan_id_and_active", unique: true
     t.index ["user_id"], name: "index_subscriptions_on_user_id"
+  end
+
+  create_table "user_plan_changes", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "old_plan_id"
+    t.string "new_plan_id"
+    t.string "user_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "users", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_10_17_102956) do
+ActiveRecord::Schema.define(version: 2019_10_18_102113) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -111,6 +111,7 @@ ActiveRecord::Schema.define(version: 2019_10_17_102956) do
     t.string "user_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.integer "status", default: 0
   end
 
   create_table "users", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/spec/factories/user_plan_changes.rb
+++ b/spec/factories/user_plan_changes.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :user_plan_change do
+    old_plan_id { Faker::Internet.uuid }
+    new_plan_id { Faker::Internet.uuid }
+    user
+  end
+end

--- a/spec/features/plan_change_spec.rb
+++ b/spec/features/plan_change_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'As a logged user that wants to change plans', type: :feature do
+  let!(:active_plan) { FactoryBot.create(:plan) }
+  let!(:new_plan) { FactoryBot.create(:plan) }
+  let!(:user) { FactoryBot.create(:user, stripe_id: nil) }
+  let!(:subscription) { FactoryBot.create(:subscription, plan: active_plan, user: user) }
+
+  it 'I am able to downgrade/upgrade my plan', js: true do
+    allow_any_instance_of(SessionProvider).to receive(:current_user).and_return(user)
+
+    visit "/users/#{user.id}"
+
+    within '#contact-data' do
+      expect(page).to have_content(user.name)
+    end
+    expect(page).to have_content("You're subscribed")
+
+    click_link 'Change Subscription'
+
+    expect(page).to have_content('Available plans')
+
+    within "#plan-#{active_plan.id}" do
+      expect(page).to have_content(active_plan.name)
+    end
+
+    within "#plan-#{new_plan.id}" do
+      expect(page).to have_content(new_plan.name)
+      click_button 'Pick plan'
+    end
+
+    expect(page).to have_content('We have changed your subscription successfully.')
+  end
+end

--- a/spec/features/plan_change_spec.rb
+++ b/spec/features/plan_change_spec.rb
@@ -10,7 +10,7 @@ describe 'As a logged user that wants to change plans', type: :feature do
 
   it 'I am able to downgrade/upgrade my plan', js: true do
     allow_any_instance_of(SessionProvider).to receive(:current_user).and_return(user)
-
+    expect(UserPlanChange.where(user_id: user.id).length).to be(0)
     visit "/users/#{user.id}"
 
     within '#contact-data' do
@@ -32,5 +32,6 @@ describe 'As a logged user that wants to change plans', type: :feature do
     end
 
     expect(page).to have_content('We have changed your subscription successfully.')
+    expect(UserPlanChange.where(user_id: user.id).length).to be(1)
   end
 end

--- a/spec/jobs/change_subscription_plans_job_spec.rb
+++ b/spec/jobs/change_subscription_plans_job_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ChangeSubscriptionPlansJob, type: :job do
+  let(:user) { FactoryBot.create(:user) }
+  let!(:old_plan) { FactoryBot.create(:plan) }
+  let!(:new_plan) { FactoryBot.create(:plan) }
+  let!(:active_subscription) { FactoryBot.create(:subscription, user: user, plan: old_plan) }
+  let!(:plan_change) { FactoryBot.create(:user_plan_change, user: user, old_plan_id: old_plan.id, new_plan_id: new_plan.id, status: 'pending') }
+
+  subject(:job) { described_class.perform_later }
+
+  it 'queues the job' do
+    expect { job }
+      .to change(ActiveJob::Base.queue_adapter.enqueued_jobs, :size).by(1)
+  end
+
+  it 'is in default queue' do
+    expect(ChangeSubscriptionPlansJob.new.queue_name).to eq('default')
+  end
+
+  it 'executes perform' do
+    expect do
+      described_class.perform_now
+    end.to change(ActiveJob::Base.queue_adapter.enqueued_jobs, :size).by(1)
+  end
+
+  after do
+    clear_enqueued_jobs
+    clear_performed_jobs
+  end
+end

--- a/spec/jobs/toggle_user_active_subscription_plan_job_spec.rb
+++ b/spec/jobs/toggle_user_active_subscription_plan_job_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ToggleUserActiveSubscriptionPlanJob do
+  let(:user) { FactoryBot.create(:user) }
+  let!(:old_plan) { FactoryBot.create(:plan) }
+  let!(:new_plan) { FactoryBot.create(:plan) }
+  let!(:active_subscription) { FactoryBot.create(:subscription, user: user, plan: old_plan) }
+  let!(:plan_change) { FactoryBot.create(:user_plan_change, user: user, old_plan_id: old_plan.id, new_plan_id: new_plan.id, status: 'pending') }
+
+  subject(:job) { described_class.perform_later(plan_change) }
+
+  it 'queues the job' do
+    expect { job }
+      .to change(ActiveJob::Base.queue_adapter.enqueued_jobs, :size).by(1)
+  end
+
+  it 'is in default queue' do
+    expect(ToggleUserActiveSubscriptionPlanJob.new.queue_name).to eq('default')
+  end
+
+  it 'executes perform' do
+    expect(Subscription.count).to eq(1)
+    expect(user.active_subscription.plan.id).to eq(old_plan.id)
+
+    perform_enqueued_jobs { job }
+
+    expect(Subscription.count).to eq(2)
+    user.active_subscription.reload
+    expect(user.active_subscription.plan.id).to eq(new_plan.id)
+    expect(plan_change.reload.status).to eq('finished')
+  end
+
+  after do
+    clear_enqueued_jobs
+    clear_performed_jobs
+  end
+end

--- a/spec/models/user_plan_change_spec.rb
+++ b/spec/models/user_plan_change_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe UserPlanChange, type: :model do
+  let!(:user_plan_change) { FactoryBot.create(:user_plan_change) }
+
+  subject { user_plan_change }
+
+  describe 'attributes' do
+    it { is_expected.to respond_to(:user) }
+    it { is_expected.to respond_to(:old_plan_id) }
+    it { is_expected.to respond_to(:new_plan_id) }
+    it { is_expected.to be_valid }
+  end
+
+  describe 'validations' do
+    it { is_expected.to validate_presence_of(:user_id) }
+    it { is_expected.to validate_presence_of(:old_plan_id) }
+    it { is_expected.to validate_presence_of(:new_plan_id) }
+
+    it { is_expected.to validate_uniqueness_of(:user_id) }
+  end
+end


### PR DESCRIPTION
**What:**
User should be able to upgrade/downgrade their subscription

**Why:**
For users to increase or decrease their contribution without admin intervention
Closes #22 

**How:**
In the Subscription section in the back-office, User now has a Change Subscription button, that allows choosing from the existing plans a new plan (disabling his/her current plan from the selectable options)

## Screenshots
Logged as a user
<img width="1792" alt="image" src="https://user-images.githubusercontent.com/1833858/67094128-6ce68f00-f1b3-11e9-8794-bfa4468ffc7a.png">

Available plans to select
<img width="1792" alt="image" src="https://user-images.githubusercontent.com/1833858/67094137-707a1600-f1b3-11e9-9f1e-6143584fb540.png">

After choosing a different plan
<img width="1792" alt="image" src="https://user-images.githubusercontent.com/1833858/67094149-766ff700-f1b3-11e9-91cb-2e9ed47119ba.png">

Profile after plan change was applied
<img width="1792" alt="image" src="https://user-images.githubusercontent.com/1833858/67094528-54c33f80-f1b4-11e9-8b6d-385885a24acc.png">
