### PR TITLE
add redirect to /admin/users from base /admin

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,6 +30,8 @@ Rails.application.routes.draw do
   get '/login' => 'sessions#login'
   get '/signup' => 'sessions#signup'
 
+  get '/admin' => redirect('/admin/users')
+
   if Rails.env.production?
     mount Sidekiq::Web => '/sidekiq', constraints: AdminConstraint.new(require_master: true)
   else


### PR DESCRIPTION
**What:**
Add redirection from `/admin` to `/admin/users`

**Why:**
To make admins see the available routes and not display a not found route for it.

**How:**
By adding a redirection route on rails routes
