### PR TITLE
feat(streak): modify string to display membership in months

### DIFF
--- a/app/controllers/streaks_controller.rb
+++ b/app/controllers/streaks_controller.rb
@@ -4,7 +4,7 @@ class StreaksController < ApplicationController
   before_action :set_user, only: %i[show]
 
   def show
-    render json: {current_streak: @user.current_streak}
+    render json: { current_streak: "#{@user.current_streak} months" }
   end
 
   private

--- a/app/controllers/streaks_controller.rb
+++ b/app/controllers/streaks_controller.rb
@@ -4,7 +4,7 @@ class StreaksController < ApplicationController
   before_action :set_user, only: %i[show]
 
   def show
-    render json: { current_streak: "#{@user.current_streak} months" }
+    render json: { current_streak: @user.current_streak ? "#{@user.current_streak} months" : 'Currently don\'t own an activr subscription' }
   end
 
   private

--- a/app/controllers/streaks_controller.rb
+++ b/app/controllers/streaks_controller.rb
@@ -4,7 +4,7 @@ class StreaksController < ApplicationController
   before_action :set_user, only: %i[show]
 
   def show
-    render json: { current_streak: @user.current_streak ? "#{@user.current_streak} months" : 'Currently don\'t own an activr subscription' }
+    render json: { current_streak: @user.current_streak ? "#{@user.current_streak} months" : "You don't have an active membership" }
   end
 
   private

--- a/app/javascript/bundles/User/components/UserShow.jsx
+++ b/app/javascript/bundles/User/components/UserShow.jsx
@@ -19,7 +19,7 @@ function UserShowView ({ user, subscription, streak }) {
     <>
       {subscription && subscription.active && streak && (
         <p className='notice--subscription'>
-          You have been subscribed for {streak}
+          You have been a member for {streak} month{streak > 1 ? 's' : ''}
         </p>
       )}
       <Paper className={classes.root} id='contact-data'>

--- a/app/javascript/bundles/User/components/UserShow.jsx
+++ b/app/javascript/bundles/User/components/UserShow.jsx
@@ -40,7 +40,7 @@ function UserShowView ({ user, subscription, streak }) {
 
 UserShowView.propTypes = {
   user: PropTypes.object.isRequired,
-  streak: PropTypes.string,
+  streak: PropTypes.number,
   subscription: PropTypes.object.isRequired
 }
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -32,12 +32,12 @@ class User < ApplicationRecord
   end
 
   def current_streak
-    return 'Currently, you don\'t own an active subscription' unless active_subscription
+    return nil unless active_subscription
 
     start_date ||= active_subscription.start_date
-    
-    return 1 if Date.today - start_date.to_date == 0 # first month of subscription
-    
+
+    return 1 if (Date.today - start_date.to_date).zero? # first month of subscription
+
     ((Date.today - start_date.to_date).to_f / 365 * 12).round
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -36,7 +36,7 @@ class User < ApplicationRecord
 
     start_date ||= active_subscription.start_date
 
-    time_ago_in_words(start_date)
+    ((Date.today - start_date.to_date).to_f / 365 * 12).round
   end
 
   def active_subscription

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -35,7 +35,9 @@ class User < ApplicationRecord
     return 'Currently, you don\'t own an active subscription' unless active_subscription
 
     start_date ||= active_subscription.start_date
-
+    
+    return 1 if Date.today - start_date.to_date == 0 # first month of subscription
+    
     ((Date.today - start_date.to_date).to_f / 365 * 12).round
   end
 


### PR DESCRIPTION
**What:**
Change the way the API of current user streak gets displayed
related #163

**Why:**
To display always months

**How:**
By changing the method that calculates the time between the current subscription and the streak.

## Screenshot
<img width="1089" alt="image" src="https://user-images.githubusercontent.com/1833858/70053386-a04f7280-15d5-11ea-8e7d-4ef19f3fc611.png">
