### PR TITLE
fix(subscription): fix stripe description of recurring subscription

### DIFF
--- a/app/jobs/subscription_payment_job.rb
+++ b/app/jobs/subscription_payment_job.rb
@@ -33,7 +33,7 @@ class SubscriptionPaymentJob < ApplicationJob
       Stripe::Charge.create(
         customer: customer,
         amount: (plan.amount * 100).to_i, # amount in cents
-        description: "Charged #{displayable_amount(plan.amount)} for #{plan.name}",
+        description: "Charged #{displayable_amount(plan.amount * 100)} for #{plan.name}",
         currency: 'usd',
         metadata: { 'plan_id' => plan.id, 'user_id' => subscription.user.id }
       )


### PR DESCRIPTION
**What:**
Fixes description on stripe renewal charge
closes #196 

**Why:**
Because the charge was misleading compared to what we actually charged the customer.

**How:**
By doing the same comparison for the charge amount