### PR TITLE
197 | Increase minimum donation

### DIFF
--- a/app/controllers/charges_controller.rb
+++ b/app/controllers/charges_controller.rb
@@ -11,6 +11,11 @@ class ChargesController < ApplicationController
     return unless verify_recaptcha
     return if @amount.nil? || @amount.zero? || @amount.negative?
 
+    if @amount < 500
+      Raven.capture_message("#{current_user&.id ? "We couldn't process payment for user_id: #{current_user.id}. " : ''} To increase the security of our payment provider integration, the minimum amount that can be donated is $5 USD", extra: { params: params })
+      return
+    end
+
     charge = current_user ? save_donation_from(current_user, params) : charge_donation_of_anonymous_user(params)
     notice = "Thank you for donating #{displayable_amount(@amount)}."
 

--- a/app/jobs/subscription_payment_job.rb
+++ b/app/jobs/subscription_payment_job.rb
@@ -66,7 +66,7 @@ class SubscriptionPaymentJob < ApplicationJob
 
   def create_donation(subscription, stripe_charge)
     new_charge = Donation.new(
-      amount: subscription.plan.amount / 100, # transformed from cents
+      amount: subscription.plan.amount,
       customer_stripe_id: subscription.user.stripe_id,
       donation_type: Donation::DONATION_TYPES[:subscription],
       user_id: subscription.user.id,

--- a/app/models/donation.rb
+++ b/app/models/donation.rb
@@ -4,7 +4,6 @@ class Donation < ApplicationRecord
   DONATION_TYPES = { one_off: 'ONE_OFF', subscription: 'SUBSCRIPTION' }.freeze
   enum status: %i[finished pending archived failed]
 
-
   validates :amount, :customer_stripe_id, :donation_type, presence: true
-  validates :amount, numericality: true
+  validates :amount, numericality: { greater_than_or_equal_to: 5 }, presence: true
 end

--- a/app/views/charges/new.html.erb
+++ b/app/views/charges/new.html.erb
@@ -25,7 +25,7 @@
           <!-- Used to display form errors. -->
         </div>
 
-        <%= form.number_field :amount, step: 1, placeholder: '$0', class: 'input-field', id: 'amount-field' %>
+        <%= form.number_field :amount, step: 1, placeholder: '$5', class: 'input-field', id: 'amount-field' %>
 
         <%= recaptcha_tags %>
         <button id="submit-payment" class="button primary">Make my donation</button>

--- a/app/views/shared/_stripe_scripts.html.erb
+++ b/app/views/shared/_stripe_scripts.html.erb
@@ -49,7 +49,10 @@
       amountField.addEventListener('input', function(event) {
         if (amountField.value.length === 0) {
           submitPaymentButton.setAttribute("disabled", "disabled")
-        } else {
+        } else if(amountField.value < 5) {
+          submitPaymentButton.setAttribute("disabled", "disabled")
+        }
+        else {
           submitPaymentButton.removeAttribute("disabled", "disabled");
         };
       });

--- a/app/views/shared/_stripe_scripts.html.erb
+++ b/app/views/shared/_stripe_scripts.html.erb
@@ -40,6 +40,9 @@
         displayError.textContent = '';
         submitPaymentButton.removeAttribute("disabled", "disabled");
       }
+      if(amountField.value < 5) {
+        submitPaymentButton.setAttribute("disabled", "disabled")
+      }
     });
 
     // disable submit button by default

--- a/spec/features/donations_spec.rb
+++ b/spec/features/donations_spec.rb
@@ -27,6 +27,31 @@ describe 'Donations', type: :feature do
       end
     end
 
+    it 'fails when trying to donate less than $5' do
+      allow_any_instance_of(SessionProvider).to receive(:current_user).and_return(user)
+      visit '/'
+      expect(page).to_not have_content('Log In') # checking user is logged in
+      expect(page).to have_content('Pay what you can')
+
+      click_link 'one-time-donation'
+
+      expect(page).to have_content('Pay what you can. Every dollar counts.')
+
+      within '.one-time-donation' do
+        fill_stripe_elements(card: '4242424242424242')
+        fill_in 'amount-field', with: 4
+        expect(page).to have_button('Make my donation', disabled: true)
+        fill_in 'amount-field', with: 5
+        expect(page).to have_button('Make my donation', disabled: false)
+        fill_in 'amount-field', with: 2
+        expect(page).to have_button('Make my donation', disabled: true)
+      end
+
+      using_wait_time(10) do
+        expect(page).to_not have_content('Thank you for donating $4.00')
+      end
+    end
+
     it 'notifies when the transaction was declined' do
       allow_any_instance_of(SessionProvider).to receive(:current_user).and_return(user)
       visit '/'

--- a/spec/models/donations_spec.rb
+++ b/spec/models/donations_spec.rb
@@ -21,5 +21,6 @@ RSpec.describe Donation, type: :model do
     it { is_expected.to validate_presence_of(:customer_stripe_id) }
     it { is_expected.to validate_presence_of(:donation_type) }
     it { is_expected.to allow_value(1235.123).for(:amount) }
+    it { is_expected.to_not allow_value(4.123).for(:amount) }
   end
 end


### PR DESCRIPTION
**What:**
Increase the min donation from $1 to $5, keeps the donation field disabled until the user ups the amount from $4.99.

Updated placeholder to show the min amount.

**Why:**
We are getting transactions that are being blocked due to being high-risk transactions in Stripe. This is a measure that aims to reduce these transactions.
closes #197 

**How:**
By adding verifications in the front-end and backend code.

**Other thoughts:**
@orlando adding a config in the admin view sounds like a nice to have, but I feel having this minimum right now, is more important, to avoid being blocked by stripe, let me know your thoughts.
