### PR TITLE
ci: deploy to production after manual approval

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -222,6 +222,47 @@ jobs:
           command: |
             aws ecs update-service --cluster $ECS_CLUSTER --service $ECS_SERVICE --force-new-deployment
 
+  deploy_prod:
+    working_directory: ~/fundraising
+    docker:
+      - image: circleci/ruby:2.6.5-node-browsers
+    environment:
+      ECS_CLUSTER: prod
+      ECS_SERVICE: fundraising
+    steps:
+      - checkout
+      - aws-cli/install
+      - aws-cli/configure
+
+      # restore cache
+      - restore_cache:
+          keys:
+            - fundraising-{{ checksum "Gemfile.lock" }}-{{ checksum "yarn.lock" }}
+            - fundraising-{{ checksum "Gemfile.lock" }}
+            - fundraising-
+
+      - run:
+          name: configure bundler
+          command: |
+            echo 'export BUNDLER_VERSION=$(cat Gemfile.lock | tail -1 | tr -d " ")' >> $BASH_ENV
+            source $BASH_ENV
+            gem install bundler
+
+      - run:
+          name: install dependencies
+          command: |
+            bundle install --path vendor/bundle
+
+      - run:
+          name: Migrate database
+          command: |
+            bundle exec ruby scripts/ecs_db_migrate.rb
+
+      - run:
+          name: Deploy task with new version
+          command: |
+                    aws ecs update-service --cluster $ECS_CLUSTER --service $ECS_SERVICE --force-new-deployment
+
 workflows:
   version: 2
   pipeline:
@@ -250,6 +291,19 @@ workflows:
       - deploy_stage:
           requires:
             - publish_latest
+          filters:
+            branches:
+              only: master
+      - deploy_prod_approval:
+          type: approval
+          requires:
+            - publish_latest
+          filters:
+            branches:
+              only: master
+      - deploy_prod:
+          requires:
+            - deploy_prod_approval
           filters:
             branches:
               only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -288,12 +288,6 @@ workflows:
           filters:
             branches:
               only: master
-      - deploy_stage:
-          requires:
-            - publish_latest
-          filters:
-            branches:
-              only: master
       - deploy_prod_approval:
           type: approval
           requires:


### PR DESCRIPTION
**What:** deploy to production after manual approval. This PR adds a new manual approval step before deploying to production.

**Why:** To be able to deploy directly from CI

**How:**

- Modify `circleci.yml` to include the deployment steps for prod