### PR TITLE
fix: admin link and admin route should link to admin/dashboard

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -19,6 +19,10 @@ class ApplicationController < ActionController::Base
 
   private
 
+  def set_hostname
+    @hostname = request.host || 'https://membership.debtcollective.org'
+  end
+
   def set_raven_context
     Raven.user_context(
       id: current_user&.id,

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -19,10 +19,6 @@ class ApplicationController < ActionController::Base
 
   private
 
-  def set_hostname
-    @hostname = request.host || 'https://membership.debtcollective.org'
-  end
-
   def set_raven_context
     Raven.user_context(
       id: current_user&.id,

--- a/app/views/static_pages/home.html.erb
+++ b/app/views/static_pages/home.html.erb
@@ -2,7 +2,7 @@
   <meta property="og:title" content="Debt Collective - Membership" />
   <meta property="og:description" content="Organizing for big change requires resources. Becoming a dues- paying member is not charity. Instead, your support is an act of ongoing solidarity with other people in debt." />
   <meta property="og:type" content="text/html" />
-  <meta property="og:url" content="https://membership.debtcollective.org" />
+  <meta property="og:url" content="<%= @hostname %>" />
   <meta property="og:image" content="<%= asset_url('logo-small.png') %>" />
 <% end %>
 
@@ -14,7 +14,9 @@
       <li><a href="https://powerreport.debtcollective.org/" target="_blank" rel="follow">The Power Report</a></li>
       <li><a href="http://community.debtcollective.org/" target="_blank" rel="follow">Community</a></li>
       <% if @current_user && @current_user.admin? %>
-        <li><a href="https://membership.debtcollective.org/admin" rel="nofollow">Admin</a></li>
+        <li>
+          <%= link_to "Admin", admin_dashboard_path, data: { turbolinks: false } %>
+        </li>
       <% end %>
     </ul>
     <ul>

--- a/app/views/static_pages/home.html.erb
+++ b/app/views/static_pages/home.html.erb
@@ -2,7 +2,7 @@
   <meta property="og:title" content="Debt Collective - Membership" />
   <meta property="og:description" content="Organizing for big change requires resources. Becoming a dues- paying member is not charity. Instead, your support is an act of ongoing solidarity with other people in debt." />
   <meta property="og:type" content="text/html" />
-  <meta property="og:url" content="<%= @hostname %>" />
+  <meta property="og:url" content="<%= request.original_url %>" />
   <meta property="og:image" content="<%= asset_url('logo-small.png') %>" />
 <% end %>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,6 +20,8 @@ Rails.application.routes.draw do
     resources :donations, only: %i[index show]
   end
 
+  get '/admin', to: redirect('/admin/dashboard')
+
   resources :users, only: %i[show new edit update create destroy] do
     get '/subscription' => 'users#subscription', as: :current_subscription
     get '/donations' => 'users#donation_history', as: :latest_donations
@@ -31,8 +33,6 @@ Rails.application.routes.draw do
 
   get '/login' => 'sessions#login'
   get '/signup' => 'sessions#signup'
-
-  get '/admin' => redirect('/admin/users')
 
   if Rails.env.production?
     mount Sidekiq::Web => '/sidekiq', constraints: AdminConstraint.new(require_master: true)


### PR DESCRIPTION
**What:** Fix admin link in navigation

https://www.loom.com/share/527c381eb67f4124a427871ea10d4ce4

**Why:** Close #194 

**How:**

- Fix redirect `/admin`
- Use link_to instead of hardcoded link
