### PR TITLE
fix: prevent Drawer from breaking when changing between admin and user backends

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -18,8 +18,13 @@ class ApplicationController < ActionController::Base
   end
 
   def authenticate_user!
-    # TODO: redirect to login instead
-    head :unauthorized unless logged_in?
+    unless logged_in?
+      if request.format.json?
+        head :unauthorized
+      else
+        redirect_to root_path
+      end
+    end
   end
 
   private

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -2,8 +2,8 @@
 
 class UsersController < ApplicationController
   layout 'backoffice'
+  before_action :authenticate_user!
   before_action :set_user
-  before_action :verify_current_user
 
   # GET /users/1
   # GET /users/1.json

--- a/app/views/static_pages/home.html.erb
+++ b/app/views/static_pages/home.html.erb
@@ -21,7 +21,9 @@
     </ul>
     <ul>
       <% if @current_user %>
-        <li><a href="<%= user_path(@current_user) %>" class="button primary" rel="nofollow">My Profile</a></li>
+        <li>
+          <%= link_to "My Account", user_path(@current_user), class: "button primary", data: { turbolinks: false } %>
+        </li>
       <% else %>
         <li><a href="<%= login_path %>" class="button secondary" rel="nofollow">Log In</a></li>
         <li><a href="<%= signup_path %>" class="button primary" rel="nofollow">Sign Up</a></li>


### PR DESCRIPTION
**What:** prevent Drawer from breaking when changing between admin and user backends

https://www.loom.com/share/079b5f617b7f40a2b09a8bc92ffee780

**Why:** To prevent the front-end from breaking

**How:**

- Disable turbolinks for Account link in navigation
- Refactor authenticate_user to handle JSON requests 