### PR TITLE
Add annotate gem and fix sentry releases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,7 +82,7 @@ jobs:
           name: build image
           command: |
             export IMAGE_TAG=$(echo $CIRCLE_SHA1 | cut -c -7)
-            make build tag=$IMAGE_TAG
+            docker build --build-arg sentry_release=$IMAGE_TAG -t debtcollective/fundraising:$IMAGE_TAG .
 
       - run:
           name: Archive Docker image
@@ -262,7 +262,76 @@ jobs:
       - run:
           name: Deploy task with new version
           command: |
-                    aws ecs update-service --cluster $ECS_CLUSTER --service $ECS_SERVICE --force-new-deployment
+            aws ecs update-service --cluster $ECS_CLUSTER --service $ECS_SERVICE --force-new-deployment
+
+  sentry_release:
+    working_directory: ~/fundraising
+    docker:
+      - image: circleci/ruby:2.7.1-node-browsers
+        environment:
+          PGHOST: localhost
+          PGUSER: fundraising
+          RAILS_ENV: test
+          DATABASE_URL: postgres://fundraising:letmein@localhost/fundraising_test?pool=5
+      - image: postgres:10
+        environment:
+          POSTGRES_USER: fundraising
+          POSTGRES_DB: fundraising_test
+          POSTGRES_PASSWORD: "letmein"
+    steps:
+      - checkout
+
+      - run:
+          name: configure bundler
+          command: |
+            echo 'export BUNDLER_VERSION=$(cat Gemfile.lock | tail -1 | tr -d " ")' >> $BASH_ENV
+            source $BASH_ENV
+            gem install bundler
+
+      # restore cache
+      - restore_cache:
+          keys:
+            - fundraising-{{ checksum "Gemfile.lock" }}-{{ checksum "yarn.lock" }}
+            - fundraising-{{ checksum "Gemfile.lock" }}
+            - fundraising-
+
+      - run:
+          name: install dependencies
+          command: |
+            bundle install --path vendor/bundle
+            yarn install
+
+      # write cache
+      - save_cache:
+          key: fundraising-{{ checksum "Gemfile.lock" }}-{{ checksum "yarn.lock" }}
+          paths:
+            - vendor/bundle
+            - ~/.cache/yarn
+
+      - run:
+          name: wait for postgres
+          command: dockerize -wait tcp://localhost:5432 -timeout 1m
+
+      - run:
+          name: dotenv
+          command: cp .env.template .env
+
+      - run:
+          name: setup db
+          command: bundle exec rake db:setup
+
+      - run:
+          name: compile assets
+          command: |
+            export IMAGE_TAG=$(echo $CIRCLE_SHA1 | cut -c -7)
+            env SENTRY_RELEASE=$IMAGE_TAG SECRET_KEY_BASE=`bundle exec rake secret` bundle exec rake assets:precompile --trace
+
+      - run:
+          name: sentry release
+          command: |
+            export IMAGE_TAG=$(echo $CIRCLE_SHA1 | cut -c -7)
+            ./node_modules/.bin/sentry-cli releases deploys $IMAGE_TAG new -e production
+
 
 workflows:
   version: 2
@@ -283,6 +352,13 @@ workflows:
             branches:
               only: master
       - publish_latest:
+          requires:
+            - test
+            - build
+          filters:
+            branches:
+              only: master
+      - sentry_release:
           requires:
             - test
             - build

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,8 +31,12 @@ RUN apt install ./forego-stable-linux-amd64.deb
 
 ADD . $APP_HOME
 
+# set sentry release
+ARG sentry_release=
+ENV SENTRY_RELEASE=${sentry_release}
+
 RUN yarn install --check-files
-RUN SECRET_KEY_BASE=`bundle exec rake secret` bundle exec rake assets:precompile --trace
+RUN env SECRET_KEY_BASE=`bundle exec rake secret` bundle exec rake assets:precompile --trace
 
 # set this until Rails warnings are fixed in Ruby 2.7
 ENV RUBYOPT='-W:no-deprecated -W:no-experimental'

--- a/Gemfile
+++ b/Gemfile
@@ -67,6 +67,7 @@ group :development, :test do
   gem 'faker', '~> 2.1', '>= 2.1.2'
   gem 'factory_bot', '~> 5.0', '>= 5.0.2'
   gem 'factory_bot_rails', '~> 5.0', '>= 5.0.2'
+  gem 'annotate', '3.1.1'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -109,6 +109,9 @@ GEM
       zeitwerk (~> 2.2)
     addressable (2.6.0)
       public_suffix (>= 2.0.2, < 4.0)
+    annotate (3.1.1)
+      activerecord (>= 3.2, < 7.0)
+      rake (>= 10.4, < 14.0)
     ast (2.4.0)
     backport (1.1.2)
     bindex (0.8.1)
@@ -371,6 +374,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  annotate (= 3.1.1)
   bootsnap (= 1.4.6)
   byebug
   capybara (~> 3.28)

--- a/app/models/card.rb
+++ b/app/models/card.rb
@@ -1,3 +1,21 @@
+# == Schema Information
+#
+# Table name: cards
+#
+#  id             :bigint           not null, primary key
+#  brand          :string
+#  exp_month      :integer
+#  exp_year       :integer
+#  last_digits    :string
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#  stripe_card_id :string
+#  user_id        :bigint
+#
+# Indexes
+#
+#  index_cards_on_user_id  (user_id)
+#
 class Card < ApplicationRecord
   belongs_to :user
 

--- a/app/models/donation.rb
+++ b/app/models/donation.rb
@@ -1,5 +1,25 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: donations
+#
+#  id                 :bigint           not null, primary key
+#  amount             :money
+#  customer_ip        :string
+#  donation_type      :string
+#  status             :integer          default("finished")
+#  user_data          :json             not null
+#  created_at         :datetime         not null
+#  updated_at         :datetime         not null
+#  card_id            :string
+#  customer_stripe_id :string
+#  user_id            :bigint
+#
+# Indexes
+#
+#  index_donations_on_user_id  (user_id)
+#
 class Donation < ApplicationRecord
   DONATION_TYPES = { one_off: 'ONE_OFF', subscription: 'SUBSCRIPTION' }.freeze
   enum status: %i[finished pending archived failed]

--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -1,5 +1,17 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: plans
+#
+#  id          :bigint           not null, primary key
+#  amount      :money
+#  description :text
+#  headline    :string
+#  name        :string
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#
 class Plan < ApplicationRecord
   validates :name, :headline, :amount, presence: true
   validates :amount, numericality: true

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -1,5 +1,24 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: subscriptions
+#
+#  id             :bigint           not null, primary key
+#  active         :boolean
+#  last_charge_at :datetime
+#  start_date     :datetime
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#  plan_id        :bigint
+#  user_id        :bigint
+#
+# Indexes
+#
+#  index_subscriptions_on_plan_id                         (plan_id)
+#  index_subscriptions_on_user_id                         (user_id)
+#  index_subscriptions_on_user_id_and_plan_id_and_active  (user_id,plan_id,active) UNIQUE
+#
 class Subscription < ApplicationRecord
   before_create :store_start_date
 

--- a/app/models/subscription_donation.rb
+++ b/app/models/subscription_donation.rb
@@ -1,3 +1,19 @@
+# == Schema Information
+#
+# Table name: subscription_donations
+#
+#  id              :bigint           not null, primary key
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  donation_id     :bigint
+#  subscription_id :bigint
+#
+# Indexes
+#
+#  index_subscription_donations_on_donation_id                      (donation_id)
+#  index_subscription_donations_on_subscription_id                  (subscription_id)
+#  index_subscription_donations_on_subscription_id_and_donation_id  (subscription_id,donation_id) UNIQUE
+#
 class SubscriptionDonation < ApplicationRecord
   belongs_to :donation
   belongs_to :subscription

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,22 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: users
+#
+#  id            :bigint           not null, primary key
+#  admin         :boolean          default(FALSE)
+#  avatar_url    :string
+#  banned        :boolean          default(FALSE)
+#  custom_fields :jsonb
+#  email         :string
+#  name          :string
+#  username      :string
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#  external_id   :bigint
+#  stripe_id     :string
+#
 class User < ApplicationRecord
   include ActionView::Helpers::DateHelper
 

--- a/app/models/user_plan_change.rb
+++ b/app/models/user_plan_change.rb
@@ -1,5 +1,17 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: user_plan_changes
+#
+#  id          :bigint           not null, primary key
+#  status      :integer          default("finished")
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#  new_plan_id :string
+#  old_plan_id :string
+#  user_id     :string
+#
 class UserPlanChange < ApplicationRecord
   belongs_to :user
 

--- a/config/webpack/production.js
+++ b/config/webpack/production.js
@@ -3,9 +3,9 @@ process.env.NODE_ENV = process.env.NODE_ENV || 'production'
 const environment = require('./environment')
 const SentryCliPlugin = require('@sentry/webpack-plugin');
 
-// Only generate sentry releases when building master
-if (process.env.CI && process.env.CIRCLE_BRANCH === 'master') {
-  const release = (process.env.CIRCLE_SHA1).substring(0, 7)
+// Only generate sentry releases when SENTRY_RELEASE is available
+if (process.env.SENTRY_RELEASE) {
+  const release = process.env.SENTRY_RELEASE
 
   environment.plugins.append('sentry', new SentryCliPlugin({
     ignore: ['node_modules', 'webpack.config.js', 'vendor'],

--- a/lib/tasks/auto_annotate_models.rake
+++ b/lib/tasks/auto_annotate_models.rake
@@ -1,0 +1,59 @@
+# NOTE: only doing this in development as some production environments (Heroku)
+# NOTE: are sensitive to local FS writes, and besides -- it's just not proper
+# NOTE: to have a dev-mode tool do its thing in production.
+if Rails.env.development?
+  require 'annotate'
+  task :set_annotation_options do
+    # You can override any of these by setting an environment variable of the
+    # same name.
+    Annotate.set_defaults(
+      'active_admin'                => 'false',
+      'additional_file_patterns'    => [],
+      'routes'                      => 'false',
+      'models'                      => 'true',
+      'position_in_routes'          => 'before',
+      'position_in_class'           => 'before',
+      'position_in_test'            => 'before',
+      'position_in_fixture'         => 'before',
+      'position_in_factory'         => 'before',
+      'position_in_serializer'      => 'before',
+      'show_foreign_keys'           => 'true',
+      'show_complete_foreign_keys'  => 'false',
+      'show_indexes'                => 'true',
+      'simple_indexes'              => 'false',
+      'model_dir'                   => 'app/models',
+      'root_dir'                    => '',
+      'include_version'             => 'false',
+      'require'                     => '',
+      'exclude_tests'               => 'false',
+      'exclude_fixtures'            => 'false',
+      'exclude_factories'           => 'false',
+      'exclude_serializers'         => 'false',
+      'exclude_scaffolds'           => 'true',
+      'exclude_controllers'         => 'true',
+      'exclude_helpers'             => 'true',
+      'exclude_sti_subclasses'      => 'false',
+      'ignore_model_sub_dir'        => 'false',
+      'ignore_columns'              => nil,
+      'ignore_routes'               => nil,
+      'ignore_unknown_models'       => 'false',
+      'hide_limit_column_types'     => 'integer,bigint,boolean',
+      'hide_default_column_types'   => 'json,jsonb,hstore',
+      'skip_on_db_migrate'          => 'false',
+      'format_bare'                 => 'true',
+      'format_rdoc'                 => 'false',
+      'format_yard'                 => 'false',
+      'format_markdown'             => 'false',
+      'sort'                        => 'false',
+      'force'                       => 'false',
+      'frozen'                      => 'false',
+      'classified_sort'             => 'true',
+      'trace'                       => 'false',
+      'wrapper_open'                => nil,
+      'wrapper_close'               => nil,
+      'with_comment'                => 'true'
+    )
+  end
+
+  Annotate.load_tasks
+end

--- a/spec/factories/cards.rb
+++ b/spec/factories/cards.rb
@@ -1,5 +1,23 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: cards
+#
+#  id             :bigint           not null, primary key
+#  brand          :string
+#  exp_month      :integer
+#  exp_year       :integer
+#  last_digits    :string
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#  stripe_card_id :string
+#  user_id        :bigint
+#
+# Indexes
+#
+#  index_cards_on_user_id  (user_id)
+#
 FactoryBot.define do
   factory :card do
     user

--- a/spec/factories/donations.rb
+++ b/spec/factories/donations.rb
@@ -1,5 +1,25 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: donations
+#
+#  id                 :bigint           not null, primary key
+#  amount             :money
+#  customer_ip        :string
+#  donation_type      :string
+#  status             :integer          default("finished")
+#  user_data          :json             not null
+#  created_at         :datetime         not null
+#  updated_at         :datetime         not null
+#  card_id            :string
+#  customer_stripe_id :string
+#  user_id            :bigint
+#
+# Indexes
+#
+#  index_donations_on_user_id  (user_id)
+#
 FactoryBot.define do
   factory :donation do
     amount { Faker::Number.decimal(l_digits: 2, r_digits: 2) }

--- a/spec/factories/plans.rb
+++ b/spec/factories/plans.rb
@@ -1,5 +1,17 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: plans
+#
+#  id          :bigint           not null, primary key
+#  amount      :money
+#  description :text
+#  headline    :string
+#  name        :string
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#
 FactoryBot.define do
   factory :plan do
     name { Faker::Lorem.sentence(word_count: 3) }

--- a/spec/factories/subscription_donations.rb
+++ b/spec/factories/subscription_donations.rb
@@ -1,5 +1,21 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: subscription_donations
+#
+#  id              :bigint           not null, primary key
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  donation_id     :bigint
+#  subscription_id :bigint
+#
+# Indexes
+#
+#  index_subscription_donations_on_donation_id                      (donation_id)
+#  index_subscription_donations_on_subscription_id                  (subscription_id)
+#  index_subscription_donations_on_subscription_id_and_donation_id  (subscription_id,donation_id) UNIQUE
+#
 FactoryBot.define do
   factory :subscription_donation do
     subscription

--- a/spec/factories/subscriptions.rb
+++ b/spec/factories/subscriptions.rb
@@ -1,5 +1,24 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: subscriptions
+#
+#  id             :bigint           not null, primary key
+#  active         :boolean
+#  last_charge_at :datetime
+#  start_date     :datetime
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#  plan_id        :bigint
+#  user_id        :bigint
+#
+# Indexes
+#
+#  index_subscriptions_on_plan_id                         (plan_id)
+#  index_subscriptions_on_user_id                         (user_id)
+#  index_subscriptions_on_user_id_and_plan_id_and_active  (user_id,plan_id,active) UNIQUE
+#
 FactoryBot.define do
   factory :subscription do
     active { true }

--- a/spec/factories/user_plan_changes.rb
+++ b/spec/factories/user_plan_changes.rb
@@ -1,5 +1,17 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: user_plan_changes
+#
+#  id          :bigint           not null, primary key
+#  status      :integer          default("finished")
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#  new_plan_id :string
+#  old_plan_id :string
+#  user_id     :string
+#
 FactoryBot.define do
   factory :user_plan_change do
     old_plan_id { Faker::Internet.uuid }

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,5 +1,22 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: users
+#
+#  id            :bigint           not null, primary key
+#  admin         :boolean          default(FALSE)
+#  avatar_url    :string
+#  banned        :boolean          default(FALSE)
+#  custom_fields :jsonb
+#  email         :string
+#  name          :string
+#  username      :string
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#  external_id   :bigint
+#  stripe_id     :string
+#
 FactoryBot.define do
   sequence :external_id do |n|
     n

--- a/spec/models/user_plan_change_spec.rb
+++ b/spec/models/user_plan_change_spec.rb
@@ -1,5 +1,17 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: user_plan_changes
+#
+#  id          :bigint           not null, primary key
+#  status      :integer          default("finished")
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#  new_plan_id :string
+#  old_plan_id :string
+#  user_id     :string
+#
 require 'rails_helper'
 
 RSpec.describe UserPlanChange, type: :model do


### PR DESCRIPTION
**What:** Add annotate gem and fix sentry releases 

**Why:** Annotate will give us information about the models while we inspect them, and source maps in sentry weren't working correctly.

**How:**

- add `annotate` gem
- set SENTRY_RELEASE variable at build time in CI