### PR TITLE
fix(home-log): add a link to wrap the header logo

### DIFF
--- a/app/views/static_pages/home.html.erb
+++ b/app/views/static_pages/home.html.erb
@@ -8,7 +8,7 @@
 
 <header>
   <nav class="main-nav">
-    <%= image_tag('logo-light.svg', alt: 'Debt Collective')%>
+    <%= link_to image_tag("logo-light.svg", :alt => "Debt Collective"), 'https://debtcollective.org/' %>
     <ul class="links">
       <li><a href="http://tools.debtcollective.org/" target="_blank" rel="follow">Dispute your debt</a></li>
       <li><a href="https://powerreport.debtcollective.org/" target="_blank" rel="follow">The Power Report</a></li>


### PR DESCRIPTION
**What:**
Allow logo to redirect to the debtcollective.org website

**Why:**
https://app.asana.com/0/1168997577035609/1172273375528964

**How:**
- Use a `link_to` helper