### PR TITLE
Fix footer

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -22,8 +22,18 @@ body {
   height: 100%;
 }
 
+.content {
+  flex: 1 0 auto;
+}
+
+.footer {
+  flex-shrink: 0;
+}
+
 body {
-  background: #e9e9e9;
+  background: #FCFBF7;
+  display: flex;
+  flex-direction: column;
 }
 
 * {

--- a/app/views/static_pages/home.html.erb
+++ b/app/views/static_pages/home.html.erb
@@ -6,6 +6,7 @@
   <meta property="og:image" content="<%= asset_url('logo-small.png') %>" />
 <% end %>
 
+<div class="content">
 <header>
   <nav class="main-nav">
     <%= link_to image_tag("logo-light.svg", :alt => "Debt Collective"), '/' %>
@@ -111,6 +112,7 @@
     <a href="https://teespring.com/stores/debt-collective" class="button primary as-block" target="_blank">Browse the Shop</a>
   </section>
 </main>
+</div>
 
 <footer>
   <nav>

--- a/app/views/static_pages/home.html.erb
+++ b/app/views/static_pages/home.html.erb
@@ -8,7 +8,7 @@
 
 <header>
   <nav class="main-nav">
-    <%= link_to image_tag("logo-light.svg", :alt => "Debt Collective"), 'https://debtcollective.org/' %>
+    <%= link_to image_tag("logo-light.svg", :alt => "Debt Collective"), '/' %>
     <ul class="links">
       <li><a href="http://tools.debtcollective.org/" target="_blank" rel="follow">Dispute your debt</a></li>
       <li><a href="https://powerreport.debtcollective.org/" target="_blank" rel="follow">The Power Report</a></li>


### PR DESCRIPTION
**What:**
Add `body` tag min-height 100% so it can stretch as the content needs

**Why:**
re https://app.asana.com/0/1168997577035609/1176609034746260

**How:**
Take flex-box approach from [CSS Tricks](https://css-tricks.com/couple-takes-sticky-footer/)

**Media:**
[How it looks without content](https://user-images.githubusercontent.com/1425162/87313861-cac9bc80-c522-11ea-80de-3f9e6e2d8bf4.png)
[How it looks with full content as in production](http://recordit.co/uDb8WvgTSn)

**Important: the issue was happening in chrome Mac OS too, checkout the live app and the footer is not being rendered and placed in the middle of the screen**

**Extras:**
Add logo href back to homepage of this app _(changes were never deployed before)_