### PR TITLE
ci: fix sentry sourcemaps upload

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,7 @@ jobs:
       - save_cache:
           key: membership-{{ checksum "Gemfile.lock" }}-{{ checksum "yarn.lock" }}
           paths:
-            - vendor/bundle
+            - ~/membership/vendor/bundle
             - ~/.cache/yarn
 
       - run:
@@ -83,8 +83,6 @@ jobs:
             export IMAGE_TAG=$(echo $CIRCLE_SHA1 | cut -c -7)
             docker build \
               --build-arg sentry_release=$IMAGE_TAG \
-              --build-arg sentry_project=$SENTRY_PROJECT \
-              --build-arg sentry_org=$SENTRY_ORG \
               --build-arg sentry_auth_token=$SENTRY_AUTH_TOKEN \
               -t debtcollective/membership:$IMAGE_TAG .
 

--- a/.prettierignore
+++ b/.prettierignore
@@ -10,5 +10,4 @@ node_modules
 log
 lib
 db
-config
 bin

--- a/.sentryclirc
+++ b/.sentryclirc
@@ -1,0 +1,6 @@
+[defaults]
+org=debtcollective
+project=membership
+
+[log]
+level = debug

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,12 +33,8 @@ ADD . $APP_HOME
 
 # set sentry release
 ARG sentry_release=""
-ARG sentry_project=""
-ARG sentry_org=""
 ARG sentry_auth_token=""
 ENV SENTRY_RELEASE=${sentry_release}
-ENV SENTRY_PROJECT=${sentry_project}
-ENV SENTRY_ORG=${sentry_org}
 ENV SENTRY_AUTH_TOKEN=${sentry_auth_token}
 
 RUN yarn install --check-files

--- a/config/webpack/production.js
+++ b/config/webpack/production.js
@@ -1,22 +1,23 @@
 process.env.NODE_ENV = process.env.NODE_ENV || 'production'
 
 const environment = require('./environment')
-const SentryCliPlugin = require('@sentry/webpack-plugin');
+const SentryCliPlugin = require('@sentry/webpack-plugin')
 
 // Only generate sentry releases when Senry is configured
-if (process.env.SENTRY_RELEASE && process.env.SENTRY_ORG) {
+if (process.env.SENTRY_RELEASE && process.env.SENTRY_AUTH_TOKEN) {
   const release = process.env.SENTRY_RELEASE
 
-  environment.plugins.append('sentry', new SentryCliPlugin({
-    ignore: ['node_modules', 'webpack.config.js', 'vendor'],
-    include: ['app/javascript', 'public/assets'],
-    release,
-    setCommits: {
-      commit: release,
-      repo: 'debtcollective/membership',
-    }
-  }))
+  environment.plugins.append(
+    'sentry',
+    new SentryCliPlugin({
+      ignore: ['node_modules', 'webpack.config.js', 'vendor'],
+      include: ['app/javascript', 'public/assets'],
+      release,
+      setCommits: {
+        repo: 'https://github.com/debtcollective/membership.git'
+      }
+    })
+  )
 }
-
 
 module.exports = environment.toWebpackConfig()

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     }
   },
   "lint-staged": {
-    "app/**/*.{js,jsx}": [
+    "*.{js,jsx,json}": [
       "npm run format"
     ]
   },


### PR DESCRIPTION
**What:** fix sentry sourcemaps upload

**Why:** Fixes https://app.asana.com/0/1168997577035609/1186563322147171

**How:**

SentryCLI was having issues when passing the repository as an environment variable. We are now using a `.sentryclirc` file with the same details and the uploads of sourcemaps now works.

Here's the build log on CircleCI https://app.circleci.com/pipelines/github/debtcollective/membership/821/workflows/859e0779-38d0-4b76-bc5b-deaaa9bae3d4/jobs/1558