### PR TITLE
fix(mailer): use number_to_currency directly in email template

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -24,8 +24,4 @@ module ApplicationHelper
 
     nil
   end
-
-  def displayable_amount(amount)
-    DonationService.displayable_amount(amount)
-  end
 end

--- a/app/views/donation_mailer/thank_you_email.html.inky
+++ b/app/views/donation_mailer/thank_you_email.html.inky
@@ -59,7 +59,7 @@
         Your contribution receipt
       </h4>
       <p class="text-right donation-amount mb-0">
-        <%= displayable_amount(@donation.amount) %>
+        <%= number_to_currency(@donation.amount) %>
       </p>
       <p class="text-right text-md">
         One-time contribution
@@ -78,7 +78,7 @@
     </columns>
     <columns large="6">
       <p class="text-right mb-0">
-        <%= displayable_amount(@donation.amount) %>
+        <%= number_to_currency(@donation.amount) %>
       </p>
     </columns>
   </row>
@@ -98,7 +98,7 @@
     <columns large="6">
       <p class="text-right">
         <b>
-          <%= displayable_amount(@donation.amount) %>
+          <%= number_to_currency(@donation.amount) %>
         </b>
       </p>
     </columns>


### PR DESCRIPTION
**What:** use number_to_currency directly in email template

**Why:** fixes an issue with wrong amount values in the thank you email

**How:**

**Media:**

Before:
![image](https://user-images.githubusercontent.com/849872/92336642-6893c080-f068-11ea-88a7-c963328ad9f4.png)

After:
![image](https://user-images.githubusercontent.com/849872/92336648-79443680-f068-11ea-8951-67d234f4b870.png)
