### PR TITLE
Remove client-side custom validations and leave browser's native validations

### DIFF
--- a/app/assets/stylesheets/_alerts.scss
+++ b/app/assets/stylesheets/_alerts.scss
@@ -1,11 +1,10 @@
 @import 'base/globals';
 
 .alert {
-  margin: 1rem 5rem;
-  padding: 1rem 1.25rem;
+  margin: 1rem auto;
+  padding: 1rem 3rem 1rem 1rem;
   border: 1px solid transparent;
   border-radius: 5px;
-  padding-right: 1rem;
   color: $alert-info-text-color;
   background-color: $alert-info-background;
   border-color: $alert-info-border-color;
@@ -17,7 +16,7 @@
     border: 0;
     color: inherit;
     font-size: 1.5rem;
-    padding: .75rem 1.25rem;
+    padding: 0.75rem 1.25rem;
     position: absolute;
     right: 0;
     top: 0;

--- a/app/assets/stylesheets/_forms.scss
+++ b/app/assets/stylesheets/_forms.scss
@@ -18,15 +18,10 @@
   border: 0.0625rem solid transparent;
   border-radius: 0.25rem;
   background-color: white;
-  box-shadow: 0 0.0625rem 0.1875rem 0 #e6ebf1;
+  box-shadow: 0 0.0625rem 0.1875rem 0 #cfd7df;
   transition: box-shadow 150ms ease;
   width: 100%;
   font-size: 16px;
-}
-
-.input-field:focus,
-.StripeElement--focus {
-  box-shadow: 0 0.0625rem 0.1875rem 0 #cfd7df;
 }
 
 .StripeElement--invalid {

--- a/app/assets/stylesheets/_forms.scss
+++ b/app/assets/stylesheets/_forms.scss
@@ -1,25 +1,29 @@
 @import 'base/globals';
 
-#card-errors {
+#card-errors,
+#captcha-errors {
   font-size: 80%;
   color: #fa755a;
-  margin-bottom: 0.5rem;;
+  margin-bottom: 0.5rem;
+}
+
+.form-row {
+  margin-bottom: 1rem;
 }
 
 .input-field,
 .StripeElement {
   box-sizing: border-box;
-  height: 2.5rem;
   padding: 0.625rem 0.75rem;
   border: 0.0625rem solid transparent;
   border-radius: 0.25rem;
   background-color: white;
   box-shadow: 0 0.0625rem 0.1875rem 0 #e6ebf1;
   transition: box-shadow 150ms ease;
-  margin-bottom: 1rem;
   width: 100%;
   font-size: 16px;
 }
+
 .input-field:focus,
 .StripeElement--focus {
   box-shadow: 0 0.0625rem 0.1875rem 0 #cfd7df;
@@ -31,8 +35,4 @@
 
 .StripeElement--webkit-autofill {
   background-color: #fefde5 !important;
-}
-
-.g-recaptcha {
-  margin-bottom: 1rem;
 }

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -22,7 +22,7 @@ body {
   margin: 0;
   padding: 0;
   font-family: 'Libre Franklin', sans-serif;
-  height: 100%;
+  min-height: 100%;
 }
 
 .content {
@@ -34,7 +34,12 @@ body {
 }
 
 body {
-  background: linear-gradient($bg-color-primary, $bg-color-secondary 50%);
+  background: linear-gradient(
+    180deg,
+    $bg-color-primary 0%,
+    $bg-color-secondary 88.74%
+  );
+  background-repeat: no-repeat;
   display: flex;
   flex-direction: column;
 }

--- a/app/assets/stylesheets/checkout.scss
+++ b/app/assets/stylesheets/checkout.scss
@@ -28,14 +28,17 @@
     }
   }
 
-  .form-row {
-    label {
-      margin-bottom: 1rem;
-    }
+  .help-text {
+    color: #32325d;
+  }
 
-    .input-field {
-      margin-bottom: 1rem;
-    }
+  #amount-field {
+    margin-bottom: 0rem;
+  }
+
+  .recaptcha-wrapper {
+    margin-top: 0.5rem;
+    margin-bottom: 0.5rem;
   }
 }
 

--- a/app/assets/stylesheets/static-pages.scss
+++ b/app/assets/stylesheets/static-pages.scss
@@ -5,8 +5,6 @@
 @import 'base/globals';
 
 #money {
-  background: linear-gradient($bg-color-secondary, $bg-color-primary 50%);
-
   @media (min-width: 48rem) {
     background: no-repeat center/cover image_url('donate_photo_1.jpg');
   }
@@ -18,10 +16,6 @@
   @media (min-width: 48rem) {
     background: no-repeat center/cover image_url('donate_photo_2.jpg');
   }
-}
-
-#retail {
-  background: linear-gradient($bg-color-primary, $bg-color-secondary 50%);
 }
 
 #money,

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -15,6 +15,6 @@ document.addEventListener('DOMContentLoaded', function (event) {
 
   alert &&
     alert.addEventListener('click', function () {
-      this.parentElement.remove()
+      this.parentNode.parentNode.removeChild(this.parentNode)
     })
 })

--- a/app/views/charges/new.html.erb
+++ b/app/views/charges/new.html.erb
@@ -72,8 +72,7 @@
         <div class="form-row">
           <div class="recaptcha-wrapper">
             <%= recaptcha_tags %>
-            <div id="captcha-errors" role="alert">
-            </div>
+            <div id="captcha-errors" role="alert"></div>
           </div>
         </div>
 

--- a/app/views/charges/new.html.erb
+++ b/app/views/charges/new.html.erb
@@ -49,7 +49,7 @@
           </div>
 
           <div class="form-row">
-            <%= f.label(:card) do %>
+            <%= f.label(:card, class: 'amount-label') do %>
               Credit or debit card
               <div id="card-element">
                 <!-- A Stripe Element will be inserted here. -->
@@ -63,13 +63,21 @@
           <div class="form-row">
             <%= f.label(:amount) do %>
               Amount
-              <%= f.number_field(:amount, step: 1, min: 5, placeholder: '$5', class: 'input-field', id: 'amount-field') %>
+              <%= f.number_field(:amount, step: 1, min: 5, placeholder: '$5', class: 'input-field', id: 'amount-field', required: true) %>
+              <small class="help-text">For security reasons, the minimum donation we can accept is $5 USD. We are working to remove this limitation as soon as possible.</small>
             <% end %>
           </div>
         <% end %>
 
         <div class="form-row">
-          <%= recaptcha_tags %>
+          <div class="recaptcha-wrapper">
+            <%= recaptcha_tags %>
+            <div id="captcha-errors" role="alert">
+            </div>
+          </div>
+        </div>
+
+        <div class="form-row">
           <button id="submit-payment" type="submit" class="button primary">Make my contribution</button>
         </div>
       <% end %>

--- a/app/views/shared/_stripe_scripts.html.erb
+++ b/app/views/shared/_stripe_scripts.html.erb
@@ -28,48 +28,30 @@
 
     // Add an instance of the card Element into the `card-element` <div>.
     card.mount('#card-element');
-    const amountField = document.getElementById('amount-field')
     const submitPaymentButton = document.getElementById('submit-payment')
-    const displayError = document.getElementById('card-errors');
+    const cardDisplayError = document.getElementById('card-errors');
 
     // Handle real-time validation errors from the card Element.
     card.addEventListener('change', function(event) {
       if (event.error) {
-        displayError.textContent = event.error.message;
+        cardDisplayError.textContent = event.error.message;
       } else {
-        displayError.textContent = '';
+        cardDisplayError.textContent = '';
         submitPaymentButton.removeAttribute("disabled", "disabled");
-      }
-      if(amountField.value < 5) {
-        submitPaymentButton.setAttribute("disabled", "disabled")
       }
     });
 
-    // disable submit button by default
-    if (Boolean(amountField)) {
-      submitPaymentButton.setAttribute("disabled", "disabled")
-
-      amountField.addEventListener('input', function(event) {
-        if (amountField.value.length === 0) {
-          submitPaymentButton.setAttribute("disabled", "disabled")
-        } else if(amountField.value < 5) {
-          submitPaymentButton.setAttribute("disabled", "disabled")
-        }
-        else {
-          submitPaymentButton.removeAttribute("disabled", "disabled");
-        };
-      });
-    }
+    const captchaDisplayError = document.getElementById('captcha-errors');
 
     function verifyCaptcha() {
       let isCaptchaValidated = false;
       const captchaField = document.getElementById('g-recaptcha-response');
 
-      if(captchaField && captchaField.value.length == 0) {
+      if (captchaField && captchaField.value.length == 0) {
           isCaptchaValidated = false;
-          displayError.textContent = 'Please verify that you are a Human.';
+          captchaDisplayError.textContent = 'Please verify that you are a Human.';
       } else {
-          displayError.textContent = '';
+          captchaDisplayError.textContent = '';
           isCaptchaValidated = true;
       }
       return isCaptchaValidated
@@ -80,6 +62,7 @@
     form.addEventListener('submit', function(event) {
       event.preventDefault();
       const isCaptchaValid = verifyCaptcha()
+      submitPaymentButton.setAttribute("disabled", "disabled");
 
       if (isCaptchaValid) {
         //you can now submit your form
@@ -88,6 +71,7 @@
             // Inform the user if there was an error.
             const errorElement = document.getElementById('card-errors');
             errorElement.textContent = result.error.message;
+            submitPaymentButton.removeAttribute("disabled", "disabled");
           } else {
             // Send the token to your server.
             stripeTokenHandler(result.token);

--- a/app/views/shared/_stripe_scripts.html.erb
+++ b/app/views/shared/_stripe_scripts.html.erb
@@ -62,15 +62,17 @@
     form.addEventListener('submit', function(event) {
       event.preventDefault();
       const isCaptchaValid = verifyCaptcha()
-      submitPaymentButton.setAttribute("disabled", "disabled");
 
       if (isCaptchaValid) {
+        submitPaymentButton.setAttribute("disabled", "disabled");
+
         //you can now submit your form
         stripe.createToken(card).then(function(result) {
           if (result.error) {
             // Inform the user if there was an error.
             const errorElement = document.getElementById('card-errors');
             errorElement.textContent = result.error.message;
+
             submitPaymentButton.removeAttribute("disabled", "disabled");
           } else {
             // Send the token to your server.

--- a/app/views/subscription_charges/new.html.erb
+++ b/app/views/subscription_charges/new.html.erb
@@ -38,7 +38,13 @@
           </label>
         </div>
 
-        <%= recaptcha_tags %>
+        <div class="form-row">
+          <div class="recaptcha-wrapper">
+            <%= recaptcha_tags %>
+            <div id="captcha-errors" role="alert"></div>
+          </div>
+        </div>
+
 
         <div class="actions">
           <%= form.submit "Enroll Membership for #{number_to_currency(@plan.amount).gsub(/\.00$/, "")}/mo", class: 'button primary', id: "submit-payment" %>

--- a/spec/features/donations_spec.rb
+++ b/spec/features/donations_spec.rb
@@ -63,15 +63,10 @@ describe "Donations", type: :feature do
       within "#payment-form" do
         fill_stripe_elements(card: "4242424242424242")
         fill_in "amount-field", with: 4
-        expect(page).to have_button("Make my contribution", disabled: true)
-        fill_in "amount-field", with: 5
-        expect(page).to have_button("Make my contribution", disabled: false)
-        fill_in "amount-field", with: 2
-        expect(page).to have_button("Make my contribution", disabled: true)
-      end
+        click_button "Make my contribution"
+        message = page.find("#amount-field").native.attribute("validationMessage")
 
-      using_wait_time(10) do
-        expect(page).to_not have_content(I18n.t("charge.alerts.success", amount: "$4.00"))
+        expect(message).to eq("Value must be greater than or equal to 5.")
       end
     end
 

--- a/spec/features/subscriptions_spec.rb
+++ b/spec/features/subscriptions_spec.rb
@@ -1,75 +1,76 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
-describe 'Subscriptions', type: :feature do
-  context 'without a user account' do
+describe "Subscriptions", type: :feature do
+  context "without a user account" do
     let!(:plan) { FactoryBot.create(:plan) }
     let(:new_user) { FactoryBot.attributes_for(:user) }
 
-    xit 'allows going through the flow and prompts for a user account creation' do
-      visit '/'
-      expect(page).to have_content('Every membership brings us closer to our goals.')
+    xit "allows going through the flow and prompts for a user account creation" do
+      visit "/"
+      expect(page).to have_content("Every membership brings us closer to our goals.")
       expect(page).to have_content(plan.name)
 
       within "#subscription-#{plan.name.parameterize.underscore}" do
-        click_link 'Subscribe'
+        click_link "Subscribe"
       end
 
-      expect(page).to have_content('Please create an account')
+      expect(page).to have_content("Please create an account")
 
       # create account
-      fill_in 'Name', with: new_user[:name]
-      fill_in 'Email', with: new_user[:email]
+      fill_in "Name", with: new_user[:name]
+      fill_in "Email", with: new_user[:email]
 
-      click_button 'Continue'
+      click_button "Continue"
 
       # payment details
-      expect(page).to have_content('Payment')
+      expect(page).to have_content("Payment")
 
       # TODO: Add Stripe elements
     end
   end
 
-  context 'with a logged in user', js: true do
+  context "with a logged in user", js: true do
     let!(:plan) { FactoryBot.create(:plan, amount: 10.0) }
     let(:user) { FactoryBot.create(:user, stripe_id: nil) }
 
-    it('can start a subscription') do
+    it("can start a subscription") do
       allow_any_instance_of(SessionProvider).to receive(:current_user).and_return(user)
-      visit '/'
-      expect(page).to_not have_content('Log In') # checking user is logged in
+      visit "/"
+      expect(page).to_not have_content("Log In") # checking user is logged in
       expect(page).to have_content(plan.name)
 
       click_link "subscription-#{plan.name.parameterize.underscore}"
 
       expect(page).to have_content(plan.name)
       expect(page).to have_content(plan.description)
-      expect(page).to have_content('Credit or debit card')
-      fill_stripe_elements(card: '4242424242424242')
+      expect(page).to have_content("Credit or debit card")
+      fill_stripe_elements(card: "4242424242424242")
 
-      click_button('Enroll Membership for $10/mo')
+      click_button("Enroll Membership for $10/mo")
       using_wait_time(10) do
-        expect(page).to have_content('Thank you for subscribing')
+        expect(page).to have_content("Thank you for subscribing")
       end
     end
 
-    it 'notifies when the transaction was declined' do
+    it "notifies when the transaction was declined" do
       allow_any_instance_of(SessionProvider).to receive(:current_user).and_return(user)
-      visit '/'
-      expect(page).to_not have_content('Log In') # checking user is logged in
+      visit "/"
+      expect(page).to_not have_content("Log In") # checking user is logged in
       expect(page).to have_content(plan.name)
 
       click_link "subscription-#{plan.name.parameterize.underscore}"
 
       expect(page).to have_content(plan.name)
       expect(page).to have_content(plan.description)
-      expect(page).to have_content('Credit or debit card')
-      fill_stripe_elements(card: '4000000000000002')
+      expect(page).to have_content("Credit or debit card")
+      fill_stripe_elements(card: "4000000000000002")
 
-      click_button('Enroll Membership for $10/mo')
+      click_button("Enroll Membership for $10/mo")
+
       using_wait_time(10) do
-        expect(page).to have_content('Your card was declined')
+        expect(page).to have_content("Your card was declined")
       end
     end
   end


### PR DESCRIPTION
**What:** Remove client-side custom validations and leave browser's native validations

https://www.loom.com/share/cb5485b8e4c8493a8b153ceb2731410f

android: https://www.loom.com/share/b0daa46db9a5489792d7507bfdbb6ca7
ios: https://www.loom.com/share/f59d180b22404bb2ba184c41a0aab33b


**Why:** We had some reports that the `amount_field` validation flow was confusing and not working as expected. This PR refactors these validations to use Stripe Elements and browser native validations to work more consistently.

**How:**

- Fix some small style issues
- Remove js code for validating `amount_field`
- Fix alert close behaviour not working on Safari

