### PR TITLE
Accept one_off donations and subscriptions on the donate endpoint

### DIFF
--- a/app/controllers/charges_controller.rb
+++ b/app/controllers/charges_controller.rb
@@ -61,16 +61,17 @@ class ChargesController < ApplicationController
 
   def charge_params
     params.require(:charge).permit(
-      :name,
-      :email,
-      :phone_number,
-      :amount,
-      :stripe_token,
-      :fund_id,
-      :address_line1,
       :address_city,
       :address_country_code,
-      :address_zip
+      :address_line1,
+      :address_zip,
+      :amount,
+      :donation_type,
+      :email,
+      :fund_id,
+      :name,
+      :phone_number,
+      :stripe_token
     )
   end
 

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -6,6 +6,7 @@
 #
 #  id             :bigint           not null, primary key
 #  active         :boolean
+#  amount         :money
 #  last_charge_at :datetime
 #  start_date     :datetime
 #  created_at     :datetime         not null
@@ -43,6 +44,8 @@ class Subscription < ApplicationRecord
   end
 
   def only_one_active_subscription
+    return unless user?
+    
     if Subscription.exists?(user_id: user_id, active: true)
       errors.add(:base, 'already has an active subscription')
     end

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -23,7 +23,7 @@ class Subscription < ApplicationRecord
   before_create :store_start_date
 
   belongs_to :user, optional: true
-  belongs_to :plan
+  belongs_to :plan, optional: true
 
   validate :only_one_active_subscription, on: :create
 
@@ -45,9 +45,9 @@ class Subscription < ApplicationRecord
 
   def only_one_active_subscription
     return unless user?
-    
+
     if Subscription.exists?(user_id: user_id, active: true)
-      errors.add(:base, 'already has an active subscription')
+      errors.add(:base, "already has an active subscription")
     end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -34,10 +34,8 @@ class User < ApplicationRecord
   has_many :donations
   has_many :user_plan_changes
 
-  validates :external_id, presence: true
-
   def self.find_or_create_from_sso(payload)
-    external_id = payload.fetch('external_id')
+    external_id = payload.fetch("external_id")
 
     user = User.find_or_initialize_by(external_id: external_id)
     new_record = user.new_record?
@@ -66,7 +64,7 @@ class User < ApplicationRecord
 
     months =
       (today.year * 12 + today.month) -
-        (start_date.year * 12 + start_date.month)
+      (start_date.year * 12 + start_date.month)
     months += 1 if months == 0
 
     months

--- a/app/services/donation_service.rb
+++ b/app/services/donation_service.rb
@@ -42,16 +42,16 @@ class DonationService
     # donation can be one_time or monthly
     self.donation_type ||= "one_off"
 
-    # Stripe max length for the phone field is 20
-    self.stripe_phone_number = phone_number.truncate(20, omission: "")
-
     @user = user
   end
 
   def execute
     return Donation.new, errors unless valid?
 
-    if donation_type == "one_time"
+    # Stripe max length for the phone field is 20
+    self.stripe_phone_number = phone_number.truncate(20, omission: "")
+
+    if donation_type == "one_off"
       !!user ? save_donation_with_user : save_donation_without_user
     else
       create_recurring_donation

--- a/app/services/donation_service.rb
+++ b/app/services/donation_service.rb
@@ -245,7 +245,7 @@ class DonationService
       donation.save
 
       # Create subscription
-      subscription = Subscription.create(user_id: user.id, active: true, amount: amount, last_charge_at: DateTime.now)
+      Subscription.create(user_id: user.id, active: true, amount: amount, last_charge_at: DateTime.now)
 
       # Update stripe customer id
       @user.update(stripe_id: customer.id)

--- a/app/services/donation_service.rb
+++ b/app/services/donation_service.rb
@@ -10,10 +10,12 @@ class DonationService
     :address_zip,
     :amount,
     :customer_ip,
+    :donation_type
     :email,
     :fund_id,
     :name,
     :phone_number,
+    :stripe_phone_number
     :stripe_token
 
   validates :name, presence: true
@@ -23,6 +25,7 @@ class DonationService
   validates :stripe_token, presence: true
   validates :fund_id, presence: true
   validates :address_line1, presence: true
+  validates :donation_type, presence: true, inclusion: { in: %w(one-time monthly) }
   validates :address_city, presence: true
   validates :address_zip, presence: true
   validates :address_country_code,
@@ -36,18 +39,26 @@ class DonationService
     # amount needs to be converted to int
     self.amount = params[:amount].to_i
 
+    # donation can be one_time or monthly
+    donation_type ||= "one_time"
+
+    # Stripe max length for the phone field is 20
+    stripe_phone_number = phone_number.truncate(20, omission: "")
+
     @user = user
   end
 
   def execute
     return Donation.new, errors unless valid?
 
-    !!user ? save_donation_with_user : save_donation_without_user
+    if donation_type == "one_time"
+      !!user ? save_donation_with_user : save_donation_without_user
+    else
+      create_recurring_donation
+    end
   end
 
   def save_donation_with_user
-    # Stripe max length for the phone field is 20
-    stripe_phone_number = phone_number.truncate(20, omission: "")
     customer =
       Stripe::Customer.create(
         name: name,
@@ -107,8 +118,6 @@ class DonationService
   end
 
   def save_donation_without_user
-    # Stripe max length for the phone field is 20
-    stripe_phone_number = phone_number.truncate(20, omission: "")
     customer =
       Stripe::Customer.create(
         name: name,
@@ -163,4 +172,112 @@ class DonationService
 
     [Donation.new, errors]
   end
+
+  def create_recurring_donation
+    user = create_user unless !!user
+
+    stripe_customer_id = user.stripe_id
+
+    if stripe_customer_id
+      customer = Stripe::Customer.retrieve(user.stripe_id)
+
+      # add source to customer
+      Stripe::Customer.create_source(
+        stripe_customer_id,
+        {
+          source: stripe_token,
+        }
+      )
+
+      # make the source we just added the default one
+      Stripe::Customer.update(
+        stripe_customer_id,
+        {
+          source: stripe_token,
+        }
+      )
+    else
+      customer =
+      Stripe::Customer.create(
+        name: name,
+        email: email,
+        phone: stripe_phone_number,
+        source: stripe_token
+      )
+    end
+
+    # amount needs to be in cents for Stripe
+    amount_in_cents = amount * 100
+
+    stripe_charge =
+      Stripe::Charge.create(
+        customer: customer.id,
+        amount: amount_in_cents,
+        description: "One time contribution",
+        currency: "usd"
+      )
+
+    if stripe_charge
+      donation =
+        Donation.new(
+          amount: amount,
+          charge_data: JSON.parse(stripe_charge.to_json),
+          charge_id: stripe_charge.id,
+          charge_provider: "stripe",
+          customer_ip: customer_ip,
+          customer_stripe_id: customer.id,
+          donation_type: Donation::DONATION_TYPES[:subscription],
+          fund_id: fund_id,
+          status: stripe_charge.status,
+          user_id: user.id,
+          user_data: {
+            address_city: address_city,
+            address_country: ISO3166::Country[address_country_code].name,
+            address_country_code: address_country_code,
+            address_line1: address_line1,
+            address_zip: address_zip,
+            email: email,
+            name: name,
+            phone_number: phone_number
+          }
+        )
+
+      donation.save
+
+      # Create subscription
+      subscription = Subscription.create(user_id: user.id, active: true, amount: amount, last_charge_at: DateTime.now)
+
+      # Update stripe customer id
+      @user.update(stripe_id: customer.id)
+
+      [subscription, errors]
+    end
+  rescue Stripe::StripeError => e
+    Raven.capture_exception(e)
+
+    errors.add(:base, e.message)
+
+    [Subscription.new, errors]
+  end
+
+  private
+
+  def create_user
+    User.create({
+      name: name,
+      email: email,
+      custom_fields: {
+        address_city: address_city,
+        address_country: ISO3166::Country[address_country_code].name,
+        address_country_code: address_country_code,
+        address_line1: address_line1,
+        address_zip: address_zip,
+        email: email,
+        name: name,
+        phone_number: phone_number
+      }
+    })
+  end
+
+    Subscription.create(user_id: user.id, active: true)
 end

--- a/db/migrate/20200919014203_add_amount_to_subscription.rb
+++ b/db/migrate/20200919014203_add_amount_to_subscription.rb
@@ -1,0 +1,5 @@
+class AddAmountToSubscription < ActiveRecord::Migration[6.0]
+  def change
+    add_column :subscriptions, :amount, :money
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_14_231027) do
+ActiveRecord::Schema.define(version: 2020_09_19_014203) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -101,6 +101,7 @@ ActiveRecord::Schema.define(version: 2020_09_14_231027) do
     t.datetime "updated_at", precision: 6, null: false
     t.datetime "start_date"
     t.datetime "last_charge_at"
+    t.money "amount", scale: 2
     t.index ["plan_id"], name: "index_subscriptions_on_plan_id"
     t.index ["user_id"], name: "index_subscriptions_on_user_id"
   end

--- a/spec/factories/subscriptions.rb
+++ b/spec/factories/subscriptions.rb
@@ -6,6 +6,7 @@
 #
 #  id             :bigint           not null, primary key
 #  active         :boolean
+#  amount         :money
 #  last_charge_at :datetime
 #  start_date     :datetime
 #  created_at     :datetime         not null
@@ -22,6 +23,7 @@ FactoryBot.define do
   factory :subscription do
     active { true }
     user
+    amount { 10 }
     plan
   end
 end

--- a/spec/factories/subscriptions.rb
+++ b/spec/factories/subscriptions.rb
@@ -23,7 +23,6 @@ FactoryBot.define do
   factory :subscription do
     active { true }
     user
-    amount { 10 }
     plan
   end
 end

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -6,6 +6,7 @@
 #
 #  id             :bigint           not null, primary key
 #  active         :boolean
+#  amount         :money
 #  last_charge_at :datetime
 #  start_date     :datetime
 #  created_at     :datetime         not null

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -19,7 +19,7 @@
 #  index_subscriptions_on_plan_id  (plan_id)
 #  index_subscriptions_on_user_id  (user_id)
 #
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe Subscription, type: :model do
   let(:subscription) { FactoryBot.create(:subscription) }
@@ -27,18 +27,18 @@ RSpec.describe Subscription, type: :model do
 
   subject { subscription }
 
-  describe 'attributes' do
+  describe "attributes" do
     it { is_expected.to respond_to(:user_id) }
     it { is_expected.to respond_to(:plan_id) }
     it { is_expected.to respond_to(:active) }
     it { is_expected.to be_valid }
   end
 
-  describe 'validations' do
-    it { should belong_to(:plan) }
+  describe "validations" do
+    it { should belong_to(:plan).optional(true) }
     it { should belong_to(:user).optional(true) }
 
-    it 'can have many subscriptions' do
+    it "can have many subscriptions" do
       user = FactoryBot.create(:user)
       FactoryBot.create(:subscription, user: user, active: false)
 
@@ -53,7 +53,7 @@ RSpec.describe Subscription, type: :model do
       expect(new_subscription.errors).to be_empty
     end
 
-    it 'only can be one active subscription at a time' do
+    it "only can be one active subscription at a time" do
       user = FactoryBot.create(:user)
       FactoryBot.create(:subscription, user: user)
 
@@ -65,7 +65,7 @@ RSpec.describe Subscription, type: :model do
 
       new_subscription.save
 
-      expect(new_subscription.errors.full_messages).to eq(['already has an active subscription'])
+      expect(new_subscription.errors.full_messages).to eq(["already has an active subscription"])
     end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -37,7 +37,6 @@ RSpec.describe User, type: :model do
   end
 
   describe "validations" do
-    it { is_expected.to validate_presence_of(:external_id) }
   end
 
   describe "associations" do

--- a/spec/services/donation_service_spec.rb
+++ b/spec/services/donation_service_spec.rb
@@ -169,7 +169,7 @@ RSpec.describe DonationService, type: :service do
       expect(donation.status).to eq("succeeded")
 
       expect(user.email).to eq(params[:email])
-      expect(user.custom_fields["address_city"]).to eq(valid_params[:address_city])
+      expect(user.custom_fields["address_city"]).to eq(params[:address_city])
 
       expect(subscription.active).to eq(true)
       expect(subscription.amount).to eq(10)

--- a/spec/services/donation_service_spec.rb
+++ b/spec/services/donation_service_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe DonationService, type: :service do
       stripe_token: stripe_helper.generate_card_token
     }
   end
+
   before { StripeMock.start }
   after { StripeMock.stop }
 
@@ -122,6 +123,74 @@ RSpec.describe DonationService, type: :service do
 
       expect(errors.empty?).to eq(false)
       expect(errors["base"]).to eq(["The card was declined"])
+    end
+  end
+
+  describe ".create_recurring_donation" do
+    let(:user) { FactoryBot.create(:user) }
+    let(:fund) { FactoryBot.create(:default_fund) }
+
+    it "creates a subscription record" do
+      params = valid_params.merge({
+        stripe_token: stripe_helper.generate_card_token,
+        donation_type: "subscription"
+      })
+
+      donation, errors = DonationService.new(params, user).execute
+      subscription = user.active_subscription
+
+      expect(errors.empty?).to eq(true)
+      expect(donation).to be_persisted
+      expect(donation.amount.to_i).to eq(10)
+      # Stripe stores the amount in cents
+      expect(donation.charge_data["amount"]).to eq(donation.amount * 100)
+      expect(donation.status).to eq("succeeded")
+
+      expect(subscription.active).to eq(true)
+      expect(subscription.amount).to eq(10)
+    end
+
+    it "creates a user if not provided" do
+      params = valid_params.merge({
+        email: "newuser@example.com",
+        stripe_token: stripe_helper.generate_card_token,
+        donation_type: "subscription"
+      })
+
+      donation, errors = DonationService.new(params).execute
+      user = User.last
+      subscription = user.active_subscription
+
+      expect(errors.empty?).to eq(true)
+      expect(donation).to be_persisted
+      expect(donation.amount.to_i).to eq(10)
+      # Stripe stores the amount in cents
+      expect(donation.charge_data["amount"]).to eq(donation.amount * 100)
+      expect(donation.status).to eq("succeeded")
+
+      expect(user.email).to eq(params[:email])
+      expect(user.custom_fields["address_city"]).to eq(valid_params[:address_city])
+
+      expect(subscription.active).to eq(true)
+      expect(subscription.amount).to eq(10)
+    end
+
+    it "returns error if charge is declined" do
+      params = valid_params.merge({
+        stripe_token: stripe_helper.generate_card_token,
+        donation_type: "subscription"
+      })
+
+      StripeMock.prepare_card_error(:card_declined)
+
+      donation, errors = DonationService.new(params, user).execute
+
+      subscription = user.active_subscription
+
+      expect(errors.empty?).to eq(false)
+      expect(errors["base"]).to eq(["The card was declined"])
+
+      expect(subscription).to be_nil
     end
   end
 end


### PR DESCRIPTION
**What:** Accept one_off donations and subscriptions on the donate endpoint.

Also, I've added the ability for subscriptions to accept any amount and not just plans. For now, it will work with/without a plan, but we will deprecate plans in the near future.

**Why:** Be able to use the DonationWidget to create recurring donations (subscriptions).

**How:**

- Remove presence validation of `User.external_id`, this to create users on the membership database not linked to Discourse
- Add `donation_type` field to ChargesController
- Add `Donation.create_recurring_donation` to create a donation, a subscription and a user (if not provider)
