### PR TITLE
Send email confirmation if there's a user with the same email on Discourse

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -21,6 +21,8 @@ DISCOURSE_API_KEY=
 DISCOURSE_USERNAME=system
 DISCOURSE_ADMIN_ROLE=dispute-pro
 
+MEMBER_HUB_URL=http://lvh.me:8000/hub
+
 MAIL_FROM=The Debt Collective <admin@debtcollective.org>
 ASSET_HOST=
 SMTP_ADDRESS=

--- a/app/controllers/user_confirmations_controller.rb
+++ b/app/controllers/user_confirmations_controller.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class UserConfirmationsController < ApplicationController
+  layout "minimal"
   before_action :authenticate_user!, only: :create
 
   # GET /users/confirmation?confirmation_token=abcdef

--- a/app/controllers/user_confirmations_controller.rb
+++ b/app/controllers/user_confirmations_controller.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+class UserConfirmationsController < ApplicationController
+  before_action :authenticate_user!, only: :create
+
+  # GET /users/confirmation?confirmation_token=abcdef
+  def show
+    @confirmation_token = params[:confirmation_token]
+    @user = User.find_by_confirmation_token(@confirmation_token)
+
+    respond_to do |format|
+      format.html { render :show }
+    end
+  end
+
+  # POST /users/confirmation
+  def create
+    user = User.send_confirmation_instructions(email: current_user.email || params[:email])
+
+    if user.errors.empty?
+      format.json { render json: {status: "success", message: "Confirmation email sent"}, status: :ok }
+    else
+      format.json { render json: {status: "failed", message: "Invalid confirmation token"}, status: :not_found }
+    end
+  end
+
+  # POST /users/confirmation/confirm
+  def confirm
+    @user = User.confirm_by_token(user_confirmation_params[:confirmation_token])
+    @user_confirmed = @user.errors.empty?
+
+    if @user_confirmed
+      format.html { render :confirm, notice: "Email confirmed" }
+      format.json { render json: {status: "success", message: "Email confirmed"}, status: :ok }
+    else
+      format.html { render :confirm, notice: "Invalid confirmation token" }
+      format.json { render json: {status: "failed", message: "Invalid confirmation token"}, status: :not_found }
+    end
+  end
+
+  def user_confirmation_params
+    params.require(:user_confirmation).permit(:confirmation_token)
+  end
+end

--- a/app/controllers/user_confirmations_controller.rb
+++ b/app/controllers/user_confirmations_controller.rb
@@ -37,6 +37,9 @@ class UserConfirmationsController < ApplicationController
 
     respond_to do |format|
       if @user_confirmed
+        # run the Discourse link account job to fetch and link with a Discourse account
+        LinkDiscourseAccountJob.perform_later(@user)
+
         format.html { render :confirm, notice: "Email confirmed", status: :ok }
         format.json { render json: {status: "success", message: "Email confirmed"}, status: :ok }
       else

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -2,7 +2,7 @@
 
 class UsersController < ApplicationController
   layout "backoffice"
-  before_action :authenticate_user!
+  before_action :authenticate_user!, except: :current
   before_action :set_user
 
   # GET /users/1
@@ -23,7 +23,17 @@ class UsersController < ApplicationController
     current_page_title("Donation history")
 
     # pass donations with receipt_url attribute to react component
-    @donations = JSON.parse(@user.donations.to_json(methods: :receipt_url))
+    @donations = JSON.parse(@user.donations.as_json(methods: :receipt_url))
+  end
+
+  def current
+    respond_to do |format|
+      if @user
+        format.json { render json: @user.as_json, status: :ok }
+      else
+        format.json { render json: nil, status: :not_found }
+      end
+    end
   end
 
   private

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -23,7 +23,7 @@ class UsersController < ApplicationController
     current_page_title("Donation history")
 
     # pass donations with receipt_url attribute to react component
-    @donations = JSON.parse(@user.donations.as_json(methods: :receipt_url))
+    @donations = @user.donations.as_json(methods: :receipt_url)
   end
 
   def current

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -13,4 +13,12 @@ class UserMailer < ApplicationMailer
 
     mail to: email, from: ENV["MAIL_FROM"]
   end
+
+  def confirmation_email(user:)
+    @user = user
+    @confirmation_token = @user.confirmation_token
+    email = @user.email
+
+    mail to: email, from: ENV["MAIL_FROM"]
+  end
 end

--- a/app/models/current_user.rb
+++ b/app/models/current_user.rb
@@ -39,7 +39,7 @@ class CurrentUser < Delegator
   end
 
   def as_json
-    json = super(only: [:id, :name, :email, :external_id], methods: [:active_subscription])
+    json = super(only: [:id, :name, :email, :external_id], methods: [:active_subscription, :confirmed?])
     json["subscription"] = json.delete("active_subscription")
 
     json

--- a/app/models/current_user.rb
+++ b/app/models/current_user.rb
@@ -2,9 +2,9 @@
 
 class CurrentUser < Delegator
   attr_accessor :user, :new_record
-  alias __getobj__ user
+  alias_method :__getobj__, :user
 
-  def initialize(user, payload, new_record)
+  def initialize(user, payload = {}, new_record = false)
     @user = user
     @payload = payload
     @new_record = new_record
@@ -15,26 +15,33 @@ class CurrentUser < Delegator
   end
 
   def groups
-    @payload['groups']
+    @payload["groups"]
   end
 
   def card_background_url
-    @payload['card_background_url']
+    @payload["card_background_url"]
   end
 
   def profile_background_url
-    @payload['profile_background_url']
+    @payload["profile_background_url"]
   end
 
   def admin?
-    !!@user.admin || @payload['groups'].include?(ENV['DISCOURSE_ADMIN_ROLE'])
+    !!@user.admin || @payload["groups"].include?(ENV["DISCOURSE_ADMIN_ROLE"])
   end
 
   def moderator?
-    !!@payload['moderator']
+    !!@payload["moderator"]
   end
 
   def active?
-    !!@payload['active']
+    !!@payload["active"]
+  end
+
+  def as_json
+    json = super(only: [:id, :name, :email, :external_id], methods: [:active_subscription])
+    json["subscription"] = json.delete("active_subscription")
+
+    json
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -86,7 +86,7 @@ class User < ApplicationRecord
   end
 
   def confirmed?
-    confirmed_at.present?
+    external_id.present?|| confirmed_at.present?
   end
 
   def current_streak

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -53,12 +53,12 @@ class User < ApplicationRecord
     [user, new_record]
   end
 
-  def self.send_confirmation_instructions(attributes = {})
-    user = User.find_by_email(attributes[:email])
+  def self.send_confirmation_instructions(email:)
+    user = User.find_by_email(email)
 
     if user
       confirmation_token = user.confirmation_token || SecureRandom.hex(20)
-      user.update_attributes(confirmation_token: confirmation_token, confirmation_sent_at: DateTime.now)
+      user.update(confirmation_token: confirmation_token, confirmation_sent_at: DateTime.now)
       UserMailer.confirmation_email(user: user).deliver_later
     else
       user = User.new
@@ -72,7 +72,7 @@ class User < ApplicationRecord
     user = User.find_by_confirmation_token(confirmation_token)
 
     if user
-      user.update_attributes(confirmation_token: nil, confirmed_at: DateTime.now)
+      user.update(confirmation_token: nil, confirmed_at: DateTime.now)
     else
       user = User.new
       user.errors.add(:base, "Invalid confirmation token")

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,18 +4,21 @@
 #
 # Table name: users
 #
-#  id            :bigint           not null, primary key
-#  admin         :boolean          default(FALSE)
-#  avatar_url    :string
-#  banned        :boolean          default(FALSE)
-#  custom_fields :jsonb
-#  email         :string
-#  name          :string
-#  username      :string
-#  created_at    :datetime         not null
-#  updated_at    :datetime         not null
-#  external_id   :bigint
-#  stripe_id     :string
+#  id                         :bigint           not null, primary key
+#  admin                      :boolean          default(FALSE)
+#  avatar_url                 :string
+#  banned                     :boolean          default(FALSE)
+#  custom_fields              :jsonb
+#  email                      :string
+#  email_confirmation_sent_at :datetime
+#  email_confirmation_token   :string
+#  email_confirmed_at         :datetime
+#  name                       :string
+#  username                   :string
+#  created_at                 :datetime         not null
+#  updated_at                 :datetime         not null
+#  external_id                :bigint
+#  stripe_id                  :string
 #
 class User < ApplicationRecord
   include ActionView::Helpers::DateHelper

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -59,10 +59,23 @@ class User < ApplicationRecord
     if user
       confirmation_token = user.confirmation_token || SecureRandom.hex(20)
       user.update_attributes(confirmation_token: confirmation_token, confirmation_sent_at: DateTime.now)
-      UserMailer.confirmation_mail(user: user).deliver_later
+      UserMailer.confirmation_email(user: user).deliver_later
     else
       user = User.new
       user.errors.add(:base, "User not found")
+    end
+
+    user
+  end
+
+  def self.confirm_by_token(confirmation_token)
+    user = User.find_by_confirmation_token(confirmation_token)
+
+    if user
+      user.update_attributes(confirmation_token: nil, confirmed_at: DateTime.now)
+    else
+      user = User.new
+      user.errors.add(:base, "Invalid confirmation token")
     end
 
     user
@@ -73,7 +86,7 @@ class User < ApplicationRecord
   end
 
   def confirmed?
-    user.confirmed_at.present?
+    confirmed_at.present?
   end
 
   def current_streak

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,21 +4,21 @@
 #
 # Table name: users
 #
-#  id                         :bigint           not null, primary key
-#  admin                      :boolean          default(FALSE)
-#  avatar_url                 :string
-#  banned                     :boolean          default(FALSE)
-#  custom_fields              :jsonb
-#  email                      :string
-#  email_confirmation_sent_at :datetime
-#  email_confirmation_token   :string
-#  email_confirmed_at         :datetime
-#  name                       :string
-#  username                   :string
-#  created_at                 :datetime         not null
-#  updated_at                 :datetime         not null
-#  external_id                :bigint
-#  stripe_id                  :string
+#  id                   :bigint           not null, primary key
+#  admin                :boolean          default(FALSE)
+#  avatar_url           :string
+#  banned               :boolean          default(FALSE)
+#  confirmation_sent_at :datetime
+#  confirmation_token   :string
+#  confirmed_at         :datetime
+#  custom_fields        :jsonb
+#  email                :string
+#  name                 :string
+#  username             :string
+#  created_at           :datetime         not null
+#  updated_at           :datetime         not null
+#  external_id          :bigint
+#  stripe_id            :string
 #
 class User < ApplicationRecord
   include ActionView::Helpers::DateHelper
@@ -53,8 +53,27 @@ class User < ApplicationRecord
     [user, new_record]
   end
 
+  def self.send_confirmation_instructions(attributes = {})
+    user = User.find_by_email(attributes[:email])
+
+    if user
+      confirmation_token = user.confirmation_token || SecureRandom.hex(20)
+      user.update_attributes(confirmation_token: confirmation_token, confirmation_sent_at: DateTime.now)
+      UserMailer.confirmation_mail(user: user).deliver_later
+    else
+      user = User.new
+      user.errors.add(:base, "User not found")
+    end
+
+    user
+  end
+
   def admin?
     !!admin
+  end
+
+  def confirmed?
+    user.confirmed_at.present?
   end
 
   def current_streak

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -71,10 +71,10 @@ class User < ApplicationRecord
   end
 
   def pending_plan_change
-    user_plan_changes.where(status: :pending).first
+    @pending_plan_change ||= user_plan_changes.where(status: :pending).first
   end
 
   def active_subscription
-    subscriptions.includes(:plan).where(active: true).last
+    @active_subscription ||= subscriptions.includes(:plan).where(active: true).last
   end
 end

--- a/app/views/layouts/minimal.html.erb
+++ b/app/views/layouts/minimal.html.erb
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Membership</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <%= csrf_meta_tags %>
+    <%= csp_meta_tag %>
+    <%= content_for?(:head) ? yield(:head) : '' %>
+    <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
+    <link href="https://fonts.googleapis.com/css2?family=Libre+Franklin:wght@300;400;500;700&display=swap" rel="stylesheet" />
+
+    <link rel="apple-touch-icon" sizes="152x152" href="/apple-touch-icon.png" />
+    <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
+    <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
+    <link rel="manifest" href="/site.webmanifest" />
+    <link rel="mask-icon" href="/safari-pinned-tab.svg" color="#5bbad5" />
+    <meta name="msapplication-TileColor" content="#da532c" />
+    <meta name="theme-color" content="#ffffff" />
+
+    <%= render 'layouts/sentry' %>
+    <%= render 'shared/analytics_scripts'%>
+  </head>
+
+  <body>
+    <div class="content">
+      <%= yield %>
+    </div>
+  </body>
+</html>

--- a/app/views/user_confirmations/confirm.html.erb
+++ b/app/views/user_confirmations/confirm.html.erb
@@ -1,0 +1,7 @@
+<% if @user_confirmed %>
+  <p>Your account is now confirmed. Please visit your personalized hub by clicking the link below.</p>
+
+  <a href="<%= ENV["MEMBER_HUB_URL"]%>">Go to Member Hub</a>
+<% else %>
+  <p>Your email is not confirmed.</p>
+<% end %>

--- a/app/views/user_confirmations/confirm.html.erb
+++ b/app/views/user_confirmations/confirm.html.erb
@@ -1,7 +1,7 @@
 <% if @user_confirmed %>
   <p>Your account is now confirmed. Please visit your personalized hub by clicking the link below.</p>
 
-  <a href="<%= ENV["MEMBER_HUB_URL"]%>">Go to Member Hub</a>
+  <a href="<%= ENV["MEMBER_HUB_URL"]%>" class="button primary">Go to Member Hub</a>
 <% else %>
   <p>Your email is not confirmed.</p>
 <% end %>

--- a/app/views/user_confirmations/index.html.erb
+++ b/app/views/user_confirmations/index.html.erb
@@ -4,7 +4,7 @@
   <% else %>
     <p>Please click the button below to confirm your email</p>
 
-    <%= form_with(url: user_confirmations_confirm_path, method: 'post', local: true) do %>
+    <%= form_with(url: confirm_user_confirmations_path, method: 'post', local: true) do %>
       <%= fields_for(:user_confirmation) do |f|%>
         <%= f.hidden_field(:confirmation_token, value: @confirmation_token) %>
 

--- a/app/views/user_confirmations/show.html.erb
+++ b/app/views/user_confirmations/show.html.erb
@@ -1,0 +1,19 @@
+<% if @user %>
+  <% if @user.confirmed?%>
+    <p>This email has been already confirmed</p>
+  <% else %>
+    <p>Please click the button below to confirm your email</p>
+
+    <%= form_with(url: user_confirmations_confirm_path, method: 'post', local: true) do %>
+      <%= fields_for(:user_confirmation) do |f|%>
+        <%= f.hidden_field(:confirmation_token, value: @confirmation_token) %>
+
+        <div class="form-row">
+          <button id="submit-payment" type="submit" class="button primary">Confirm my email</button>
+        </div>
+      <% end %>
+    <% end %>
+  <% end %>
+<% else %>
+  <p>Invalid confirmation token</p>
+<% end %>

--- a/app/views/user_mailer/confirmation_email.html.inky
+++ b/app/views/user_mailer/confirmation_email.html.inky
@@ -1,0 +1,33 @@
+<container>
+  <row>
+    <columns large="12">
+      <spacer size="24"></spacer>
+      <h5>Hello <strong><%= @user.name %></strong></h5>
+
+      <p>
+        We need to confirm your email address. Please click the button below.
+      </p>
+
+      <spacer size="12"></spacer>
+
+      <button
+        href="<%= user_confirmation_url(confirmation_token: @confirmation_token) %>"
+        class="large expanded"
+      >
+        Confirm your email
+      </button>
+
+      <spacer size="12"></spacer>
+
+      <p>
+        If you have any questions, please feel free to reach out to us at
+        admin@debtcollective.org.
+      </p>
+
+      <p>
+        In solidarity,<br />
+        Debt Collective
+      </p>
+    </columns>
+  </row>
+</container>

--- a/app/views/user_mailer/confirmation_email.html.inky
+++ b/app/views/user_mailer/confirmation_email.html.inky
@@ -11,8 +11,9 @@
       <spacer size="12"></spacer>
 
       <button
-        href="<%= user_confirmation_url(confirmation_token: @confirmation_token) %>"
-        class="large expanded"
+        target="_blank"
+        href="<%= confirm_user_confirmations_url(confirmation_token: @confirmation_token) %>"
+        class="expanded"
       >
         Confirm your email
       </button>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -68,7 +68,8 @@ Rails.application.configure do
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
 
-  # Mailcatcher
+  # ActionMailer
+  config.action_mailer.default_url_options = {host: "http://#{ENV["DEV_HOST"]}:#{ENV["DEV_PORT"]}"}
   config.action_mailer.delivery_method = :smtp
   config.action_mailer.smtp_settings = {address: "127.0.0.1", port: 1025}
   config.action_mailer.raise_delivery_errors = false

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -40,6 +40,7 @@ Rails.application.configure do
   # ActionMailer::Base.deliveries array.
   config.action_mailer.delivery_method = :test
   config.active_job.queue_adapter = :test
+  config.action_mailer.default_url_options = {host: "http://localhost"}
 
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,7 +36,7 @@ Rails.application.routes.draw do
 
   get "/users/current" => "users#current", :constraints => {format: "json"}
 
-  resources :user_confirmations, only: %i[show create] do
+  resources :user_confirmations, only: %i[index create] do
     post "/confirm" => "user_confirmations#confirm", :on => :collection
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,7 +34,11 @@ Rails.application.routes.draw do
     resources :plan_changes, only: %i[index create]
   end
 
-  get "/users/current" => "users#current", :constraints => {format: "json" }
+  get "/users/current" => "users#current", :constraints => {format: "json"}
+
+  resources :user_confirmations, only: %i[show create] do
+    post "/confirm" => "user_confirmations#confirm", :on => :collection
+  end
 
   get "/login" => "sessions#login"
   get "/signup" => "sessions#signup"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,6 +34,8 @@ Rails.application.routes.draw do
     resources :plan_changes, only: %i[index create]
   end
 
+  get "/users/current" => "users#current", :constraints => {format: "json" }
+
   get "/login" => "sessions#login"
   get "/signup" => "sessions#signup"
 

--- a/db/migrate/20200925234657_add_user_confirmation.rb
+++ b/db/migrate/20200925234657_add_user_confirmation.rb
@@ -1,0 +1,7 @@
+class AddUserConfirmation < ActiveRecord::Migration[6.0]
+  def change
+    add_column :users, :confirmation_token, :string, index: true
+    add_column :users, :confirmed_at, :datetime
+    add_column :users, :confirmation_sent_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -129,9 +129,9 @@ ActiveRecord::Schema.define(version: 2020_09_25_234657) do
     t.bigint "external_id"
     t.string "name"
     t.string "username"
-    t.string "email_confirmation_token"
-    t.datetime "email_confirmed_at"
-    t.datetime "email_confirmation_sent_at"
+    t.string "confirmation_token"
+    t.datetime "confirmed_at"
+    t.datetime "confirmation_sent_at"
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_24_215740) do
+ActiveRecord::Schema.define(version: 2020_09_25_234657) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -129,6 +129,9 @@ ActiveRecord::Schema.define(version: 2020_09_24_215740) do
     t.bigint "external_id"
     t.string "name"
     t.string "username"
+    t.string "email_confirmation_token"
+    t.datetime "email_confirmed_at"
+    t.datetime "email_confirmation_sent_at"
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"

--- a/spec/controllers/user_confirmations_controller_spec.rb
+++ b/spec/controllers/user_confirmations_controller_spec.rb
@@ -46,12 +46,15 @@ RSpec.describe UserConfirmationsController, type: :controller do
     it "confirms user email if token is valid" do
       user = FactoryBot.create(:user_with_confirmation_token)
 
+      expect(LinkDiscourseAccountJob).to receive_message_chain(:perform_later)
+
       post :confirm, params: {user_confirmation: {confirmation_token: user.confirmation_token}}
       user.reload
 
       expect(response.status).to eq(200)
       expect(user.confirmed_at).to be_within(1.second).of DateTime.now
       expect(user.confirmed?).to eq(true)
+      expect(user.confirmation_token).to be_nil
     end
 
     it "returns not found if token is invalid" do

--- a/spec/controllers/user_confirmations_controller_spec.rb
+++ b/spec/controllers/user_confirmations_controller_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe UserConfirmationsController, type: :controller do
+  describe "GET #index" do
+    it "returns a success response if token is found" do
+      user = FactoryBot.create(:user_with_confirmation_token)
+
+      get :index, params: {confirmation_token: user.confirmation_token}
+
+      expect(response.status).to eq(200)
+    end
+
+    it "returns not found if token is invalid" do
+      get :index, params: {confirmation_token: SecureRandom.hex(20)}
+
+      expect(response.status).to eq(404)
+    end
+  end
+
+  describe "POST #create" do
+    # This endpoint only supports json
+    before(:each) do
+      request.accept = "application/json"
+    end
+
+    it "creates and send user confirmation instructions" do
+      user = FactoryBot.create(:user)
+
+      expect(UserMailer).to receive_message_chain(:confirmation_email, :deliver_later)
+
+      post :create, params: {email: user.email}
+
+      expect(response.status).to eq(200)
+    end
+
+    it "returns not found if token is invalid" do
+      post :create, params: {email: Faker::Internet.email}
+
+      expect(response.status).to eq(404)
+    end
+  end
+
+  describe "POST #confirm" do
+    it "confirms user email if token is valid" do
+      user = FactoryBot.create(:user_with_confirmation_token)
+
+      post :confirm, params: {user_confirmation: {confirmation_token: user.confirmation_token}}
+      user.reload
+
+      expect(response.status).to eq(200)
+      expect(user.confirmed_at).to be_within(1.second).of DateTime.now
+      expect(user.confirmed?).to eq(true)
+    end
+
+    it "returns not found if token is invalid" do
+      post :confirm, params: {user_confirmation: {confirmation_token: SecureRandom.hex(20)}}
+
+      expect(response.status).to eq(404)
+    end
+  end
+end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -1,18 +1,55 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe UsersController, type: :controller do
-  let(:valid_attributes) { FactoryBot.attributes_for(:user) }
-
   let(:valid_session) { {} }
 
-  describe 'GET #show' do
-    it 'returns a success response' do
-      user = User.create! valid_attributes
-      allow_any_instance_of(SessionProvider).to receive(:current_user).and_return(user)
-      get :show, params: { id: user.to_param }, session: valid_session
-      expect(response).to be_successful
+  describe "GET #show" do
+    it "returns a success response" do
+      user = FactoryBot.create(:user)
+      allow_any_instance_of(SessionProvider).to receive(:current_user).and_return(CurrentUser.new(user))
+
+      get :show, params: {id: user.to_param}, session: valid_session
+
+      expect(response.status).to eq(200)
+    end
+  end
+
+  describe "GET #current" do
+    before(:each) do
+      request.accept = "application/json"
+    end
+
+    it "returns 404 if no user authenticated" do
+      get :current
+
+      expect(response.status).to eq(404)
+      expect(response.body).to eq("null")
+    end
+
+    it "returns user if authenticated" do
+      user = FactoryBot.create(:user)
+      allow_any_instance_of(SessionProvider).to receive(:current_user).and_return(CurrentUser.new(user))
+
+      get :current
+      json = JSON.parse(response.body)
+
+      expect(response.status).to eq(200)
+      expect(json["id"]).to eq(user.id)
+      expect(json["subscription"]).to eq(nil)
+    end
+
+    it "returns active membership if available" do
+      user = FactoryBot.create(:user_with_subscription)
+      allow_any_instance_of(SessionProvider).to receive(:current_user).and_return(CurrentUser.new(user))
+
+      get :current
+      json = JSON.parse(response.body)
+
+      expect(response.status).to eq(200)
+      expect(json["id"]).to eq(user.id)
+      expect(json["subscription"]["id"]).to eq(user.active_subscription.id)
     end
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -4,18 +4,21 @@
 #
 # Table name: users
 #
-#  id            :bigint           not null, primary key
-#  admin         :boolean          default(FALSE)
-#  avatar_url    :string
-#  banned        :boolean          default(FALSE)
-#  custom_fields :jsonb
-#  email         :string
-#  name          :string
-#  username      :string
-#  created_at    :datetime         not null
-#  updated_at    :datetime         not null
-#  external_id   :bigint
-#  stripe_id     :string
+#  id                         :bigint           not null, primary key
+#  admin                      :boolean          default(FALSE)
+#  avatar_url                 :string
+#  banned                     :boolean          default(FALSE)
+#  custom_fields              :jsonb
+#  email                      :string
+#  email_confirmation_sent_at :datetime
+#  email_confirmation_token   :string
+#  email_confirmed_at         :datetime
+#  name                       :string
+#  username                   :string
+#  created_at                 :datetime         not null
+#  updated_at                 :datetime         not null
+#  external_id                :bigint
+#  stripe_id                  :string
 #
 FactoryBot.define do
   sequence :external_id do |n|

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -34,5 +34,9 @@ FactoryBot.define do
         FactoryBot.create(:subscription, user: user)
       end
     end
+
+    factory :user_with_confirmation_token do
+      confirmation_token { SecureRandom.hex(20) }
+    end
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -4,21 +4,21 @@
 #
 # Table name: users
 #
-#  id                         :bigint           not null, primary key
-#  admin                      :boolean          default(FALSE)
-#  avatar_url                 :string
-#  banned                     :boolean          default(FALSE)
-#  custom_fields              :jsonb
-#  email                      :string
-#  email_confirmation_sent_at :datetime
-#  email_confirmation_token   :string
-#  email_confirmed_at         :datetime
-#  name                       :string
-#  username                   :string
-#  created_at                 :datetime         not null
-#  updated_at                 :datetime         not null
-#  external_id                :bigint
-#  stripe_id                  :string
+#  id                   :bigint           not null, primary key
+#  admin                :boolean          default(FALSE)
+#  avatar_url           :string
+#  banned               :boolean          default(FALSE)
+#  confirmation_sent_at :datetime
+#  confirmation_token   :string
+#  confirmed_at         :datetime
+#  custom_fields        :jsonb
+#  email                :string
+#  name                 :string
+#  username             :string
+#  created_at           :datetime         not null
+#  updated_at           :datetime         not null
+#  external_id          :bigint
+#  stripe_id            :string
 #
 FactoryBot.define do
   sequence :external_id do |n|

--- a/spec/jobs/toggle_user_active_subscription_plan_job_spec.rb
+++ b/spec/jobs/toggle_user_active_subscription_plan_job_spec.rb
@@ -3,9 +3,9 @@
 require "rails_helper"
 
 RSpec.describe ToggleUserActiveSubscriptionPlanJob, type: :job do
-  let(:user) { FactoryBot.create(:user) }
-  let!(:old_plan) { FactoryBot.create(:plan) }
-  let!(:new_plan) { FactoryBot.create(:plan) }
+  let(:old_plan) { FactoryBot.create(:plan) }
+  let(:new_plan) { FactoryBot.create(:plan) }
+  let!(:user) { FactoryBot.create(:user) }
   let!(:active_subscription) { FactoryBot.create(:subscription, user: user, plan: old_plan) }
 
   it "queues the job" do
@@ -28,7 +28,8 @@ RSpec.describe ToggleUserActiveSubscriptionPlanJob, type: :job do
     perform_enqueued_jobs { ToggleUserActiveSubscriptionPlanJob.perform_later(plan_change) }
 
     expect(Subscription.count).to eq(2)
-    user.active_subscription.reload
+    user_id = user.id
+    user = User.find(user_id)
     plan_change.reload
 
     expect(user.active_subscription.plan.id).to eq(new_plan.id)

--- a/spec/mailers/previews/user_mailer_preview.rb
+++ b/spec/mailers/previews/user_mailer_preview.rb
@@ -6,4 +6,10 @@ class UserMailerPreview < ActionMailer::Preview
 
     UserMailer.welcome_email(user: @user)
   end
+
+  def confirmation_email
+    @user = User.new(name: "Betsy DeVos", email: "betsy.devos@ed.gov", confirmation_token: SecureRandom.hex(20))
+
+    UserMailer.confirmation_email(user: @user)
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -4,21 +4,21 @@
 #
 # Table name: users
 #
-#  id                         :bigint           not null, primary key
-#  admin                      :boolean          default(FALSE)
-#  avatar_url                 :string
-#  banned                     :boolean          default(FALSE)
-#  custom_fields              :jsonb
-#  email                      :string
-#  email_confirmation_sent_at :datetime
-#  email_confirmation_token   :string
-#  email_confirmed_at         :datetime
-#  name                       :string
-#  username                   :string
-#  created_at                 :datetime         not null
-#  updated_at                 :datetime         not null
-#  external_id                :bigint
-#  stripe_id                  :string
+#  id                   :bigint           not null, primary key
+#  admin                :boolean          default(FALSE)
+#  avatar_url           :string
+#  banned               :boolean          default(FALSE)
+#  confirmation_sent_at :datetime
+#  confirmation_token   :string
+#  confirmed_at         :datetime
+#  custom_fields        :jsonb
+#  email                :string
+#  name                 :string
+#  username             :string
+#  created_at           :datetime         not null
+#  updated_at           :datetime         not null
+#  external_id          :bigint
+#  stripe_id            :string
 #
 require "rails_helper"
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -4,18 +4,21 @@
 #
 # Table name: users
 #
-#  id            :bigint           not null, primary key
-#  admin         :boolean          default(FALSE)
-#  avatar_url    :string
-#  banned        :boolean          default(FALSE)
-#  custom_fields :jsonb
-#  email         :string
-#  name          :string
-#  username      :string
-#  created_at    :datetime         not null
-#  updated_at    :datetime         not null
-#  external_id   :bigint
-#  stripe_id     :string
+#  id                         :bigint           not null, primary key
+#  admin                      :boolean          default(FALSE)
+#  avatar_url                 :string
+#  banned                     :boolean          default(FALSE)
+#  custom_fields              :jsonb
+#  email                      :string
+#  email_confirmation_sent_at :datetime
+#  email_confirmation_token   :string
+#  email_confirmed_at         :datetime
+#  name                       :string
+#  username                   :string
+#  created_at                 :datetime         not null
+#  updated_at                 :datetime         not null
+#  external_id                :bigint
+#  stripe_id                  :string
 #
 require "rails_helper"
 


### PR DESCRIPTION
**What:** Send email confirmation if there's a user with the same email on Discourse

**Why:** Related to https://app.asana.com/0/1168997577035609/1195013675045603

**How:**

- Add confirmation email and endpoints
- Change LinkDiscourseAccountJob to send a confirmation email if there's an account on Discourse with the same email.