### PR TITLE
Cleanup and fix issue with error handling with Sentry

### DIFF
--- a/app/controllers/admin/subscriptions_controller.rb
+++ b/app/controllers/admin/subscriptions_controller.rb
@@ -2,14 +2,14 @@
 
 class Admin::SubscriptionsController < AdminController
   before_action :set_subscription, only: %i[show edit update destroy]
-  before_action -> { current_page_title('Active Subscriptions Management') }
+  before_action -> { current_page_title("Active Subscriptions Management") }
 
   # GET /admin/subscriptions
   # GET /admin/subscriptions.json
   def index
-    @subscriptions = Subscription.all.collect do |subscription|
-      { id: subscription.id, plan: subscription.plan, user: subscription.user }
-    end
+    @subscriptions = Subscription.includes(:user).all.collect { |subscription|
+      subscription.as_json(methods: [:user, :overdue?, :beyond_grace_period?])
+    }
   end
 
   # GET /admin/subscriptions/1
@@ -35,7 +35,7 @@ class Admin::SubscriptionsController < AdminController
   def update
     respond_to do |format|
       if @subscription.update(subscription_params)
-        format.html { redirect_to admin_subscription_url(@subscription), notice: 'Subscription was successfully updated.' }
+        format.html { redirect_to admin_subscription_url(@subscription), notice: "Subscription was successfully updated." }
         format.json { render :show, status: :ok, location: @subscription }
       else
         format.html { render :edit }
@@ -49,7 +49,7 @@ class Admin::SubscriptionsController < AdminController
   def destroy
     @subscription.destroy
     respond_to do |format|
-      format.html { redirect_to admin_subscriptions_url, notice: 'Subscription was successfully destroyed.' }
+      format.html { redirect_to admin_subscriptions_url, notice: "Subscription was successfully destroyed." }
       format.json { head :no_content }
     end
   end

--- a/app/javascript/bundles/Admin/components/Subscriptions/Table.jsx
+++ b/app/javascript/bundles/Admin/components/Subscriptions/Table.jsx
@@ -39,7 +39,6 @@ export default function SubcriptionsTable ({ subscriptions }) {
         </TableHead>
         <TableBody>
           {subscriptions.map(subscription => {
-            console.log(subscription)
             return (
               <TableRow key={subscription.id}>
                 <TableCell scope='subscription'>

--- a/app/javascript/bundles/Admin/components/Subscriptions/Table.jsx
+++ b/app/javascript/bundles/Admin/components/Subscriptions/Table.jsx
@@ -28,38 +28,53 @@ export default function SubcriptionsTable ({ subscriptions }) {
       <Table className={classes.table}>
         <TableHead>
           <TableRow>
-            <TableCell>User Name</TableCell>
-            <TableCell>Subscription plan</TableCell>
-            <TableCell>Subscription amount</TableCell>
+            <TableCell>Name</TableCell>
+            <TableCell>Email </TableCell>
+            <TableCell>Amount</TableCell>
+            <TableCell>Last Charged At</TableCell>
+            <TableCell>Overdue?</TableCell>
+            <TableCell>Beyond grace period?</TableCell>
             <TableCell />
           </TableRow>
         </TableHead>
         <TableBody>
-          {subscriptions.map(subscription => (
-            <TableRow key={subscription.id}>
-              <TableCell scope='subscription'>
-                {subscription.user ? `${subscription.user.name}` : 'N/A'}
-              </TableCell>
-              <TableCell>{subscription.plan.name}</TableCell>
-              <TableCell>
-                {numeral(subscription.plan.amount).format('$0,0.00')}
-              </TableCell>
-              <TableCell align='right'>
-                <a href={`/admin/subscriptions/${subscription.id}`}>Show</a>{' '}
-                <a href={`/admin/subscriptions/${subscription.id}/edit`}>
-                  Edit
-                </a>{' '}
-                <a
-                  data-confirm='Are you sure?'
-                  rel='nofollow'
-                  data-method='delete'
-                  href={`/admin/subscriptions/${subscription.id}`}
-                >
-                  Delete
-                </a>
-              </TableCell>
-            </TableRow>
-          ))}
+          {subscriptions.map(subscription => {
+            console.log(subscription)
+            return (
+              <TableRow key={subscription.id}>
+                <TableCell scope='subscription'>
+                  {subscription.user ? `${subscription.user.name}` : 'N/A'}
+                </TableCell>
+                <TableCell scope='subscription'>
+                  {subscription.user ? `${subscription.user.email}` : 'N/A'}
+                </TableCell>
+                <TableCell>
+                  {numeral(subscription.amount).format('$0,0.00')}
+                </TableCell>
+                <TableCell scope='subscription'>
+                  {subscription.last_charge_at}
+                </TableCell>
+                <TableCell>{subscription['overdue?'].toString()}</TableCell>
+                <TableCell>
+                  {subscription['beyond_grace_period?'].toString()}
+                </TableCell>
+                <TableCell align='right'>
+                  <a href={`/admin/subscriptions/${subscription.id}`}>Show</a>{' '}
+                  <a href={`/admin/subscriptions/${subscription.id}/edit`}>
+                    Edit
+                  </a>{' '}
+                  <a
+                    data-confirm='Are you sure?'
+                    rel='nofollow'
+                    data-method='delete'
+                    href={`/admin/subscriptions/${subscription.id}`}
+                  >
+                    Delete
+                  </a>
+                </TableCell>
+              </TableRow>
+            )
+          })}
         </TableBody>
       </Table>
     </Paper>

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -60,7 +60,10 @@ class Subscription < ApplicationRecord
   end
 
   def beyond_grace_period?
-    overdue? && last_charge_at <= (SUBSCRIPTION_PERIOD + GRACE_PERIOD).ago
+    return false if zero_amount?
+    return true if last_charge_at.nil?
+
+    last_charge_at <= (SUBSCRIPTION_PERIOD + GRACE_PERIOD).ago
   end
 
   def disable!

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -20,13 +20,23 @@
 #  index_subscriptions_on_user_id  (user_id)
 #
 class Subscription < ApplicationRecord
+  GRACE_PERIOD = 7.days
+  SUBSCRIPTION_PERIOD = 1.month
+
   before_create :store_start_date
 
-  belongs_to :plan, optional: true
   belongs_to :user, optional: true
+  belongs_to :plan, optional: true
   has_many :donations
 
   validate :only_one_active_subscription, on: :create
+
+  def self.overdue
+    where(active: true).where(
+      "last_charge_at IS NULL OR last_charge_at <= ?",
+      SUBSCRIPTION_PERIOD.ago
+    ).where.not(amount: 0)
+  end
 
   def user?
     !user_id.blank?
@@ -38,11 +48,23 @@ class Subscription < ApplicationRecord
     save
   end
 
-  def self.overdue
-    where(active: true).where(
-      "last_charge_at IS NULL OR last_charge_at <= ?",
-      30.days.ago
-    ).where.not(amount: 0)
+  def zero_amount?
+    amount == 0
+  end
+
+  def overdue?
+    return false if zero_amount?
+    return true if last_charge_at.nil?
+
+    last_charge_at <= SUBSCRIPTION_PERIOD.ago
+  end
+
+  def beyond_grace_period?
+    overdue? && last_charge_at <= (SUBSCRIPTION_PERIOD + GRACE_PERIOD).ago
+  end
+
+  def disable!
+    update!(active: false) if beyond_grace_period?
   end
 
   private

--- a/app/views/admin/subscriptions/show.html.erb
+++ b/app/views/admin/subscriptions/show.html.erb
@@ -6,13 +6,9 @@
 </h1>
 
 <h3>
-  <strong>Plan:</strong>
-  <%= @subscription.plan.name %>
+  <strong>Amount:</strong>
+  <%= @subscription.amount %>
 </h3>
-<p>
-  <strong>Plan description:</strong>
-  <%= @subscription.plan.description %>
-</p>
 
 <h3>Donations</h3>
 <% if @donations_history.empty? %>

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -5,7 +5,7 @@
   - mailers
 :schedule:
   find_overdue_subscriptions:
-    every: '1h'
+    every: '12h'
     queue: default
     class: FindOverdueSubscriptionsJob
     description: 'This job finds all active overdue subscriptions and creates a sidekiq job to charge the subscriber'

--- a/spec/factories/subscriptions.rb
+++ b/spec/factories/subscriptions.rb
@@ -24,6 +24,29 @@ FactoryBot.define do
     active { true }
     amount { (5..100).to_a.sample }
     user
-    plan
+
+    factory :subscription_with_donation do
+      after(:create) do |subscription|
+        donation = FactoryBot.create(:donation, subscription: subscription, amount: subscription.amount.to_i)
+
+        subscription.update(last_charge_at: donation.created_at)
+      end
+    end
+
+    factory :subscription_overdue do
+      last_charge_at { (Subscription::SUBSCRIPTION_PERIOD + 1.day).ago }
+
+      after(:create) do |subscription|
+        FactoryBot.create(:donation, subscription: subscription, amount: subscription.amount.to_i, created_at: subscription.last_charge_at)
+      end
+    end
+
+    factory :subscription_beyond_grace_period do
+      last_charge_at { (Subscription::SUBSCRIPTION_PERIOD + Subscription::GRACE_PERIOD + 1.day).ago }
+
+      after(:create) do |subscription|
+        FactoryBot.create(:donation, subscription: subscription, amount: subscription.amount.to_i, created_at: subscription.last_charge_at)
+      end
+    end
   end
 end

--- a/spec/features/admin/subscriptions_spec.rb
+++ b/spec/features/admin/subscriptions_spec.rb
@@ -1,53 +1,51 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
-describe 'Admin - Manages user subscriptions', type: :feature, js: true do
+describe "Admin - Manages user subscriptions", type: :feature, js: true do
   let!(:admin) { FactoryBot.create(:user, admin: true) }
 
   before(:each) do
     allow_any_instance_of(SessionProvider).to receive(:current_user).and_return(admin)
   end
 
-  describe 'home' do
+  describe "home" do
     let!(:subscription_1) { FactoryBot.create(:subscription) }
     let!(:subscription_2) { FactoryBot.create(:subscription) }
 
-    it 'presents a list of subscriptions' do
-      visit '/admin/subscriptions'
-      expect(page).to have_content('Subscriptions')
+    it "presents a list of subscriptions" do
+      visit "/admin/subscriptions"
+      expect(page).to have_content("Subscriptions")
 
       expect(page).to have_content(subscription_1.user.name)
-      expect(page).to have_content(subscription_1.plan.name)
-      expect(page).to have_content(subscription_1.plan.amount)
+      expect(page).to have_content(subscription_1.amount)
 
       expect(page).to have_content(subscription_2.user.name)
-      expect(page).to have_content(subscription_2.plan.name)
-      expect(page).to have_content(subscription_2.plan.amount)
+      expect(page).to have_content(subscription_2.amount)
     end
   end
 
-  describe 'edit a subscription' do
+  describe "edit a subscription" do
     let!(:subscription) { FactoryBot.create(:subscription) }
     let!(:new_plan) { FactoryBot.create(:plan) }
 
-    it 'allows changing the plan and status of a user subscription' do
+    it "allows changing the plan and status of a user subscription" do
       expect(subscription.active).to eq(true)
 
-      visit '/admin/subscriptions'
-      expect(page).to have_content('Subscriptions')
+      visit "/admin/subscriptions"
+      expect(page).to have_content("Subscriptions")
 
       expect(page).to have_content(subscription.user.name)
-      click_link('Edit', href: edit_admin_subscription_path(subscription))
+      click_link("Edit", href: edit_admin_subscription_path(subscription))
 
-      expect(page).to have_content('Editing Subscription')
-      select new_plan.name, from: 'subscription[plan_id]'
+      expect(page).to have_content("Editing Subscription")
+      select new_plan.name, from: "subscription[plan_id]"
 
-      uncheck 'subscription[active]'
+      uncheck "subscription[active]"
 
-      click_button 'Update Subscription'
+      click_button "Update Subscription"
 
-      expect(page).to have_content('Subscription was successfully updated.')
+      expect(page).to have_content("Subscription was successfully updated.")
 
       subscription.reload
 
@@ -56,19 +54,17 @@ describe 'Admin - Manages user subscriptions', type: :feature, js: true do
     end
   end
 
-  describe 'subscriptions details' do
+  describe "subscriptions details" do
     let!(:subscription) { FactoryBot.create(:subscription) }
 
-    it 'contains related donations' do
+    it "contains related donations" do
       subscription_donations = FactoryBot.create_list(:subscription_donation, 5, subscription_id: subscription.id)
 
-      visit '/admin/subscriptions'
-      expect(page).to have_content('Subscriptions')
+      visit "/admin/subscriptions"
+      expect(page).to have_content("Subscriptions")
 
       expect(page).to have_content(subscription.user.name)
-      click_link('Show', href: admin_subscription_path(subscription))
-
-      expect(page).to have_content(subscription.plan.name)
+      click_link("Show", href: admin_subscription_path(subscription))
 
       subscription_donations.each do |subscription_donation|
         donation = subscription_donation.donation

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -35,7 +35,6 @@ RSpec.describe Subscription, type: :model do
   end
 
   describe "validations" do
-    it { should belong_to(:plan).optional(true) }
     it { should belong_to(:user).optional(true) }
     it { should have_many(:donations) }
 
@@ -67,6 +66,53 @@ RSpec.describe Subscription, type: :model do
       new_subscription.save
 
       expect(new_subscription.errors.full_messages).to eq(["already has an active subscription"])
+    end
+  end
+
+  describe ".overdue?" do
+    it "returns true if subscription.last_charge_at is nil" do
+      subscription = FactoryBot.create(:subscription)
+
+      expect(subscription.last_charge_at).to be_nil
+      expect(subscription.overdue?).to eq(true)
+    end
+
+    it "returns true if subscription.last_charge_at is beyond grace period" do
+      subscription = FactoryBot.create(:subscription, last_charge_at: 2.months.ago, active: true)
+
+      expect(subscription.last_charge_at.to_i).to be_within(100).of(2.months.ago.to_i)
+      expect(subscription.overdue?).to eq(true)
+    end
+
+    it "returns false if subscription is not overdue" do
+      subscription = FactoryBot.create(:subscription_with_donation)
+
+      expect(subscription.last_charge_at.to_i).to be_within(100).of(DateTime.now.to_i)
+      expect(subscription.overdue?).to eq(false)
+    end
+  end
+
+  describe ".beyond_grace_period?" do
+    it "returns false if subscription is not overdue" do
+      subscription = FactoryBot.create(:subscription_with_donation)
+
+      expect(subscription.overdue?).to eq(false)
+      expect(subscription.beyond_grace_period?).to eq(false)
+    end
+
+    it "returns true if subscription.last_charge_at is beyond grace period" do
+      last_charge_at = (Subscription::SUBSCRIPTION_PERIOD + Subscription::GRACE_PERIOD + 1.day).ago
+      subscription = FactoryBot.create(:subscription, last_charge_at: last_charge_at)
+
+      expect(subscription.beyond_grace_period?).to eq(true)
+    end
+  end
+
+  describe ".zero_amount?" do
+    it "returns true if subscription amount is zero" do
+      subscription = FactoryBot.build(:subscription, amount: 0)
+
+      expect(subscription.zero_amount?).to eq(true)
     end
   end
 end


### PR DESCRIPTION
**What:** Cleanup and fix issue with error handling with Sentry

**Why:**  Closes https://app.asana.com/0/1196225495304457/1196457791948508

**How:**

- Cleanup subscription_payment_job
- Add test for error handling of Stripe errors in `MembershipService`

**Notes:**

This PR makes some changes related to the plans code removal. This will be fully addressed on https://app.asana.com/0/1196225495304457/1196439491713551.