### PR TITLE
don't update stripe customer sources for a one time donation.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -84,7 +84,7 @@ group :test do
   gem 'rspec-rails', '4.0.1'
   gem 'selenium-webdriver', '~> 3.142', '>= 3.142.3'
   gem 'shoulda-matchers', '~> 4.1', '>= 4.1.2'
-  gem 'stripe-ruby-mock', '~> 3.0.0', :require => 'stripe_mock'
+  gem 'stripe-ruby-mock', '3.0.1', :require => 'stripe_mock'
   gem 'timecop', '~> 0.9.1'
   gem 'webdrivers', '4.4.1'
   gem 'webmock', '3.9.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -478,7 +478,7 @@ DEPENDENCIES
   spring-watcher-listen (~> 2.0.0)
   standard (= 0.7)
   stripe (= 5.26.0)
-  stripe-ruby-mock (~> 3.0.0)
+  stripe-ruby-mock (= 3.0.1)
   thwait
   timecop (~> 0.9.1)
   turbolinks (~> 5)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -104,10 +104,17 @@ class User < ApplicationRecord
     @active_subscription ||= subscriptions.includes(:plan).where(active: true).last
   end
 
-  def find_or_create_stripe_customer
+  def find_or_create_stripe_customer(source: nil)
     return Stripe::Customer.retrieve(stripe_id) if stripe_id
 
-    stripe_customer = Stripe::Customer.create(name: name, email: email)
+    params = {
+      name: name,
+      email: email,
+    }
+
+    params[:source] = source if source
+
+    stripe_customer = Stripe::Customer.create(params)
     update!(stripe_id: stripe_customer.id)
 
     stripe_customer

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -104,29 +104,19 @@ class User < ApplicationRecord
     @active_subscription ||= subscriptions.includes(:plan).where(active: true).last
   end
 
-  def find_or_create_stripe_customer(stripe_token)
-    if stripe_id
-      stripe_customer = Stripe::Customer.retrieve(stripe_id)
-    else
-      stripe_customer = Stripe::Customer.create(email: email, source: stripe_token)
-      update!(stripe_id: stripe_customer.id)
-    end
+  def find_or_create_stripe_customer
+    return Stripe::Customer.retrieve(stripe_id) if stripe_id
+
+    stripe_customer = Stripe::Customer.create(name: name, email: email)
+    update!(stripe_id: stripe_customer.id)
 
     stripe_customer
-  rescue Stripe::CardError => e
-    # card declined
+  rescue Stripe::StripeError => e
+    # couldn't retrieve or create user, return an error
     Raven.capture_exception(e)
 
     errors.add(:base, e.message)
 
     nil
-  rescue Stripe::InvalidRequestError => e
-    # invalid stripe customer, we try to recreate it
-    Raven.capture_exception(e)
-
-    stripe_customer = Stripe::Customer.create(email: email, source: stripe_token)
-    update!(stripe_id: stripe_customer.id)
-
-    stripe_customer
   end
 end

--- a/app/services/membership_service.rb
+++ b/app/services/membership_service.rb
@@ -66,9 +66,11 @@ class MembershipService
       # Stripe max length for the phone field is 20
       self.stripe_phone_number = phone_number.truncate(20, omission: "")
       # find or create stripe customer
-      @stripe_customer = user.find_or_create_stripe_customer(stripe_token)
+      @stripe_customer = user.find_or_create_stripe_customer
 
       if @stripe_customer.nil?
+        errors.add(:base, user.errors.full_messages.first)
+
         Raven.capture_message("Couldn't find or create Stripe Customer", extra: {
           user_id: user.id,
           user_email: user.email,

--- a/app/services/membership_service.rb
+++ b/app/services/membership_service.rb
@@ -66,7 +66,7 @@ class MembershipService
       # Stripe max length for the phone field is 20
       self.stripe_phone_number = phone_number.truncate(20, omission: "")
       # find or create stripe customer
-      @stripe_customer = find_or_create_stripe_customer
+      @stripe_customer = user.find_or_create_stripe_customer(stripe_token)
 
       if @stripe_customer.nil?
         Raven.capture_message("Couldn't find or create Stripe Customer", extra: {
@@ -164,45 +164,6 @@ class MembershipService
     }
 
     user.save
-  end
-
-  def find_or_create_stripe_customer
-    if (stripe_customer_id = user.stripe_id)
-      stripe_customer = Stripe::Customer.retrieve(stripe_customer_id)
-
-      # add source to customer
-      Stripe::Customer.create_source(stripe_customer.id,
-        {
-          source: stripe_token
-        })
-
-      # add the new source to Stripe customer
-      Stripe::Customer.update(
-        stripe_customer.id,
-        {
-          source: stripe_token
-        }
-      )
-
-      stripe_customer
-    else
-      Stripe::Customer.create(email: user.email, source: stripe_token)
-    end
-  # card declined
-  rescue Stripe::CardError => e
-    Raven.capture_exception(e)
-
-    errors.add(:base, e.message)
-
-    nil
-  # invalid stripe customer, we try to recreate the stripe customer
-  rescue Stripe::InvalidRequestError => e
-    Raven.capture_exception(e)
-
-    customer = Stripe::Customer.create(email: user.email, source: stripe_token)
-    user.update!(stripe_id: customer.id)
-
-    customer
   end
 
   def link_discourse_account

--- a/app/services/membership_service.rb
+++ b/app/services/membership_service.rb
@@ -66,7 +66,7 @@ class MembershipService
       # Stripe max length for the phone field is 20
       self.stripe_phone_number = phone_number.truncate(20, omission: "")
       # find or create stripe customer
-      @stripe_customer = user.find_or_create_stripe_customer
+      @stripe_customer = user.find_or_create_stripe_customer(source: stripe_token)
 
       if @stripe_customer.nil?
         errors.add(:base, user.errors.full_messages.first)

--- a/spec/services/donation_service_spec.rb
+++ b/spec/services/donation_service_spec.rb
@@ -3,7 +3,6 @@
 require "rails_helper"
 
 RSpec.describe DonationService, type: :service do
-  let(:stripe_helper) { StripeMock.create_test_helper }
   let(:valid_params) do
     {
       address_city: Faker::Address.city,
@@ -16,7 +15,7 @@ RSpec.describe DonationService, type: :service do
       fund_id: 1,
       name: Faker::Name.name,
       phone_number: Faker::PhoneNumber.phone_number,
-      stripe_token: stripe_helper.generate_card_token
+      stripe_token: StripeMock.create_test_helper.generate_card_token
     }
   end
 
@@ -44,6 +43,7 @@ RSpec.describe DonationService, type: :service do
   describe ".save_donation_with_user" do
     let(:user) { FactoryBot.create(:user) }
     let(:fund) { FactoryBot.create(:default_fund) }
+    let!(:stripe_helper) { StripeMock.create_test_helper }
 
     it "creates a donation record" do
       params = valid_params.merge({
@@ -92,6 +92,8 @@ RSpec.describe DonationService, type: :service do
   end
 
   describe ".save_donation_without_user" do
+    let!(:stripe_helper) { StripeMock.create_test_helper }
+
     it "creates a donation record" do
       params = valid_params.merge({
         stripe_token: stripe_helper.generate_card_token

--- a/spec/services/membership_service_spec.rb
+++ b/spec/services/membership_service_spec.rb
@@ -124,7 +124,7 @@ RSpec.describe MembershipService, type: :service do
       expect(donation).to eq(nil)
     end
 
-    it "recreates stripe user if we the stripe_id is invalid" do
+    it "returns an error if stripe customer is invalid" do
       user = FactoryBot.create(:user, stripe_id: "invalid-stripe-id")
 
       params = valid_params.merge({
@@ -134,12 +134,9 @@ RSpec.describe MembershipService, type: :service do
       subscription, errors = MembershipService.new(params, user).execute
       user.reload
 
-      expect(errors.empty?).to eq(true)
-
-      expect(user.stripe_id).not_to eq("invalid-stripe-id")
-      expect(subscription.user).to eq(user)
-      expect(subscription.active).to eq(true)
-      expect(subscription.amount).to eq(10)
+      expect(errors.empty?).to eq(false)
+      expect(subscription.persisted?).to eq(false)
+      expect(errors["base"]).to eq(["No such customer: invalid-stripe-id"])
     end
 
     it "returns error if user has a subscription" do


### PR DESCRIPTION
**What:** don't update stripe customer sources for a one-time donation.

**Why:** Fixes https://app.asana.com/0/1196225495304457/1197384430829024

The goal of this PR is.

1. change the way we find or create a customer to not include a default source, this to not replace the user current source of funding if the user has an active subscription and wants to do a one-time donation.
2. make sure membership and recurring charges work as expected