### PR TITLE
fix(user_confirmation): fixes login_path not being defined

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -8,13 +8,6 @@ class SessionsController < ApplicationController
     redirect_to url
   end
 
-  def signup
-    query_string = redirect_params.to_query
-    url = "#{ENV["DISCOURSE_SIGNUP_URL"]}?#{query_string}"
-
-    redirect_to url
-  end
-
   def redirect_params
     params.permit(:return_url).reverse_merge(return_url: root_url)
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,6 +24,8 @@ Rails.application.routes.draw do
     post "/confirm" => "user_confirmations#confirm", :on => :collection
   end
 
+  get "/login" => "sessions#login"
+
   if Rails.env.production?
     mount Sidekiq::Web => "/sidekiq",
           :constraints => AdminConstraint.new(require_master: true)

--- a/spec/features/user_confirmations_spec.rb
+++ b/spec/features/user_confirmations_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe "UserConfirmations", type: :feature do
+  context "with valid token" do
+    it "validates user after completing flow" do
+      user = FactoryBot.create(:user, confirmation_token: "token")
+
+      visit "/user_confirmations?confirmation_token=#{user.confirmation_token}"
+
+      click_button "Confirm my email"
+
+      user.reload
+      expect(user.confirmed_at.to_i).to be_within(100).of(DateTime.now.to_i)
+    end
+  end
+
+  context "with invalid token" do
+    it "shows invalid token error" do
+      FactoryBot.create(:user)
+
+      visit "/user_confirmations?confirmation_token=invalid"
+
+      expect(page).to have_content("Invalid confirmation token")
+    end
+  end
+
+  context "alredy validated user" do
+    it "shows already confirmed error" do
+      user = FactoryBot.create(:user, confirmation_token: "token", confirmed_at: DateTime.now)
+
+      visit "/user_confirmations?confirmation_token=#{user.confirmation_token}"
+
+      expect(page).to have_content("This email has been already confirmed")
+    end
+  end
+end


### PR DESCRIPTION
**What:** fix(user_confirmation): fixes login_path not being defined

**Why:** Fixes https://app.asana.com/0/0/1198684972610973

**How:**

the login route was removed but this is being used by the user_confirmations. I added it back and added integration tests for this feature
