### PR TITLE
fix: store customer_ip in user custom fields when creating a donation or a membership

### DIFF
--- a/app/services/donation_service.rb
+++ b/app/services/donation_service.rb
@@ -84,7 +84,8 @@ class DonationService
             address_zip: address_zip,
             email: email,
             name: name,
-            phone_number: phone_number
+            phone_number: phone_number,
+            customer_ip: customer_ip
           }
         )
 
@@ -140,7 +141,8 @@ class DonationService
             address_zip: address_zip,
             email: email,
             name: name,
-            phone_number: phone_number
+            phone_number: phone_number,
+            customer_ip: customer_ip
           }
         )
 

--- a/app/services/membership_service.rb
+++ b/app/services/membership_service.rb
@@ -120,7 +120,8 @@ class MembershipService
           address_zip: address_zip,
           email: email,
           name: name,
-          phone_number: phone_number
+          phone_number: phone_number,
+          customer_ip: customer_ip
         }
       )
 
@@ -162,7 +163,8 @@ class MembershipService
       chapter: chapter,
       email: email,
       name: name,
-      phone_number: phone_number
+      phone_number: phone_number,
+      customer_ip: customer_ip
     }
 
     user.save

--- a/spec/services/donation_service_spec.rb
+++ b/spec/services/donation_service_spec.rb
@@ -106,6 +106,7 @@ RSpec.describe DonationService, type: :service do
       expect(donation.user_data["email"]).to eq(params[:email])
       expect(donation.user_data["name"]).to eq(params[:name])
       expect(donation.user_data["phone_number"]).to eq(params[:phone_number])
+      expect(donation.user_data["customer_ip"]).to eq(params[:customer_ip])
       expect(donation.amount.to_i).to eq(10)
       # Stripe stores the amount in cents
       expect(donation.charge_data["amount"]).to eq(donation.amount * 100)

--- a/spec/services/membership_service_spec.rb
+++ b/spec/services/membership_service_spec.rb
@@ -79,6 +79,7 @@ RSpec.describe MembershipService, type: :service do
 
       expect(user.custom_fields["address_city"]).to eq(params[:address_city])
       expect(user.custom_fields["address_zip"]).to eq(params[:address_zip])
+      expect(user.custom_fields["customer_ip"]).to eq(params[:customer_ip])
     end
 
     it "creates a user if not provided" do


### PR DESCRIPTION
**What:** store customer_ip in user custom fields when creating a donation or a membership

We use the user IP to add the email to the Mailchimp list.

**Why:** Fixes https://sentry.io/organizations/debtcollective/issues/2079854791/?project=1838195&referrer=slack

**How:**

- store `customer_ip` on `User.custom_fields`
