### PR TITLE
Add email confirmation view to preventing bots from activating accounts

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -15,14 +15,14 @@
  *= require_self
  */
 
-@import 'base/globals.scss';
+@import "base/globals.scss";
 
 html,
 body {
   font-size: 100%;
   margin: 0;
   padding: 0;
-  font-family: 'Libre Franklin', sans-serif;
+  font-family: "Libre Franklin", sans-serif;
   min-height: 100%;
 }
 
@@ -107,14 +107,4 @@ p {
 
 ul {
   line-height: 2;
-}
-
-a {
-  color: inherit;
-  text-decoration: none;
-
-  &:hover {
-    background: none;
-    text-decoration: underline;
-  }
 }

--- a/app/controllers/user_confirmations_controller.rb
+++ b/app/controllers/user_confirmations_controller.rb
@@ -49,9 +49,23 @@ class UserConfirmationsController < ApplicationController
     end
   end
 
-  # GET /user_confirmations/confirm/:email_token
+  # GET /user_confirmations/confirm_email/:email_token
   def confirm_email_token
     @user = User.find_by_email_token!(params[:email_token])
+
+    respond_to do |format|
+      if @user
+        format.html { render :index, status: :ok }
+      else
+        format.html { render :index, status: :not_found }
+      end
+    end
+  end
+
+  # POST /user_confirmations/confirm_email
+  def confirm_email
+    @email_token = user_confirmation_params[:email_token]
+    @user = User.find_by_email_token!(@email_token)
 
     respond_to do |format|
       if @user&.activate!
@@ -60,6 +74,13 @@ class UserConfirmationsController < ApplicationController
         format.html { redirect_to email_login_url }
         format.json { render json: {status: "success", message: "Email confirmed", redirect_url: email_login_url}, status: :ok }
       else
+        Raven.capture_message(
+          "Couldn't activate user with email_token",
+          extra: {
+            email_token: @email_token
+          }
+        )
+
         format.html { render plain: "We couldn't activate your account. If this is an error please contact support at https://debtcollective.org", status: :internal_server_error }
         format.json { render json: {status: "failed", message: "Invalid confirmation token"}, status: :not_found }
       end

--- a/app/controllers/user_confirmations_controller.rb
+++ b/app/controllers/user_confirmations_controller.rb
@@ -51,13 +51,14 @@ class UserConfirmationsController < ApplicationController
 
   # GET /user_confirmations/confirm_email/:email_token
   def confirm_email_token
-    @user = User.find_by_email_token!(params[:email_token])
+    @email_token = params[:email_token]
+    @user = User.find_by_email_token!(@email_token)
 
     respond_to do |format|
       if @user
-        format.html { render :index, status: :ok }
+        format.html { render :confirm_email_token, status: :ok }
       else
-        format.html { render :index, status: :not_found }
+        format.html { render :confirm_email_token, status: :not_found }
       end
     end
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -2,26 +2,30 @@
 
 module ApplicationHelper
   # Returns the full title on a per-page basis.
-  def full_title(page_title = '')
-    base_title = 'Membership'
+  def full_title(page_title = "")
+    base_title = "Membership"
     if page_title.empty?
       base_title
     else
-      page_title + ' | ' + base_title
+      page_title + " | " + base_title
     end
   end
 
   def flash_messages(_opts = {})
     flash.each do |msg_type, message|
       concat(
-        content_tag(:div, message, class: "alert alert-#{msg_type}", role: 'alert') do
+        content_tag(:div, message, class: "alert alert-#{msg_type}", role: "alert") {
           concat message
-          concat content_tag(:button, content_tag(:span, '×', data: { 'aria-hidden': 'true' }),
-                             class: 'close', data: { dismiss: 'alert' })
-        end
+          concat content_tag(:button, content_tag(:span, "×", data: {'aria-hidden': "true"}),
+            class: "close", data: {dismiss: "alert"})
+        }
       )
     end
 
     nil
+  end
+
+  def discourse_url(path="/")
+    "#{ENV["DISCOURSE_URL"]}#{path}"
   end
 end

--- a/app/jobs/link_discourse_account_job.rb
+++ b/app/jobs/link_discourse_account_job.rb
@@ -33,6 +33,7 @@ class LinkDiscourseAccountJob < ApplicationJob
       )
     end
 
+    user.username = response["username"]
     user.email_token = response["email_token"]
     user.external_id = response["user_id"]
     user.save!

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -45,6 +45,8 @@ class User < ApplicationRecord
 
   validates :email, presence: true, 'valid_email_2/email': {disposable: true}, uniqueness: {case_sensitive: false}
 
+  before_validation :normalize_attributes
+
   def self.find_or_create_from_sso(payload)
     email = payload.fetch("email")&.downcase
     external_id = payload.fetch("external_id")
@@ -122,10 +124,6 @@ class User < ApplicationRecord
     custom_fields["phone_number"]
   end
 
-  def email
-    super()&.downcase
-  end
-
   def confirmed?
     external_id.present? || confirmed_at.present?
   end
@@ -140,5 +138,11 @@ class User < ApplicationRecord
 
   def find_stripe_customer
     return Stripe::Customer.retrieve(stripe_id) if stripe_id
+  end
+
+  private
+
+  def normalize_attributes
+    self.email = email&.downcase
   end
 end

--- a/app/services/discourse_service.rb
+++ b/app/services/discourse_service.rb
@@ -37,6 +37,7 @@ class DiscourseService
       name: user.name,
       password: password,
       active: true,
+      approved: true,
       user_fields: user_fields,
       username: nil
     })

--- a/app/views/layouts/minimal.html.erb
+++ b/app/views/layouts/minimal.html.erb
@@ -6,6 +6,7 @@
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
     <%= content_for?(:head) ? yield(:head) : '' %>
+    <%= javascript_pack_tag 'application' %>
     <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
     <%= stylesheet_link_tag 'minimal', media: 'all', 'data-turbolinks-track': 'reload' %>
     <link href="https://fonts.googleapis.com/css2?family=Libre+Franklin:wght@300;400;500;700&display=swap" rel="stylesheet" />

--- a/app/views/layouts/minimal.html.erb
+++ b/app/views/layouts/minimal.html.erb
@@ -23,9 +23,9 @@
     <%= render 'shared/analytics_scripts'%>
   </head>
 
-  <body>
-    <div class="content">
+  <body data-turbolinks="false">
+    <main class="content">
       <%= yield %>
-    </div>
+    </main>
   </body>
 </html>

--- a/app/views/user_confirmations/confirm_email_token.html.erb
+++ b/app/views/user_confirmations/confirm_email_token.html.erb
@@ -1,13 +1,20 @@
 <% if @user %>
-  <p>Please click the button below to confirm your email.</p>
+  <% if @user.active? %>
+    <p>Your email has been already confirmed</p>
 
-  <%= form_with(url: confirm_user_confirmations_path, method: 'post') do %>
-    <%= fields_for(:user_confirmation) do |f|%>
-      <%= f.hidden_field(:email_token, value: @email_token) %>
+    <p><%= link_to "Click here to go to the login page", discourse_url('/login') %></p>
+  <% else %>
+    <h2>Hello <%= @user.name.titleize %>!</h2>
+    <p>Please click the button below to confirm your email.</p>
 
-      <div class="form-row">
-        <button id="submit-payment" type="submit" class="button primary">Confirm my email</button>
-      </div>
+    <%= form_with(url: confirm_email_user_confirmations_path, method: 'post') do %>
+      <%= fields_for(:user_confirmation) do |f|%>
+        <%= f.hidden_field(:email_token, value: @email_token) %>
+
+        <div class="form-row">
+          <%= f.submit "Confirm my email", id: "button-submit", class: "button primary", data: { disable_with: "Loading..."} %>
+        </div>
+      <% end %>
     <% end %>
   <% end %>
 <% else %>

--- a/app/views/user_confirmations/confirm_email_token.html.erb
+++ b/app/views/user_confirmations/confirm_email_token.html.erb
@@ -1,0 +1,15 @@
+<% if @user %>
+  <p>Please click the button below to confirm your email.</p>
+
+  <%= form_with(url: confirm_user_confirmations_path, method: 'post') do %>
+    <%= fields_for(:user_confirmation) do |f|%>
+      <%= f.hidden_field(:email_token, value: @email_token) %>
+
+      <div class="form-row">
+        <button id="submit-payment" type="submit" class="button primary">Confirm my email</button>
+      </div>
+    <% end %>
+  <% end %>
+<% else %>
+  <p>Invalid confirmation token</p>
+<% end %>

--- a/app/views/user_confirmations/index.html.erb
+++ b/app/views/user_confirmations/index.html.erb
@@ -1,6 +1,8 @@
 <% if @user %>
   <% if @user.confirmed? %>
-    <p>This email has been already confirmed</p>
+    <p>Your email has been already confirmed</p>
+
+    <p><%= link_to "Click here to go to the login page", discourse_url('/login') %></p>
   <% else %>
     <p>Please click the button below to confirm your email</p>
 
@@ -9,7 +11,7 @@
         <%= f.hidden_field(:confirmation_token, value: @confirmation_token) %>
 
         <div class="form-row">
-          <button id="submit-payment" type="submit" class="button primary">Confirm my email</button>
+          <%= f.submit "Confirm my email", id: "button-submit", class: "button primary", data: { disable_with: "Loading..."} %>
         </div>
       <% end %>
     <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,7 +23,9 @@ Rails.application.routes.draw do
   resources :user_confirmations, only: %i[index create] do
     collection do
       post "/confirm" => "user_confirmations#confirm"
-      get "/confirm/:email_token" => "user_confirmations#confirm_email_token", :as => "email_token"
+
+      get "/confirm_email/:email_token" => "user_confirmations#confirm_email_token", :as => "confirm_email_token"
+      post "/confirm_email" => "user_confirmations#confirm_email", :as => "confirm_email"
     end
   end
 

--- a/cypress/integration/email-confirmation.spec.js
+++ b/cypress/integration/email-confirmation.spec.js
@@ -1,0 +1,27 @@
+import faker from 'faker'
+
+describe('Membership Spec', () => {
+  beforeEach(() => {
+    cy.request('/cypress_rails_reset_state')
+  })
+
+  describe('happy', () => {
+    it('renders the confirmation page and user cofirms the email', () => {
+      cy.appFactories([['create', 'user_with_email_token', {}]]).then(
+        records => {
+          const user = records[0]
+          const redirectUrl = `http://lvh.me:3000/session/email-login/${user.email_token}`
+          cy.visit(`/user_confirmations/confirm_email/${user.email_token}`)
+
+          // assert the redirect
+          cy.intercept(redirectUrl, req => {
+            expect(req.url).to.eq(redirectUrl)
+            req.reply({ status: 200, body: `redirected to ${redirectUrl}` })
+          })
+
+          cy.contains('Confirm my email', { matchCase: false }).click()
+        }
+      )
+    })
+  })
+})

--- a/spec/controllers/user_confirmations_controller_spec.rb
+++ b/spec/controllers/user_confirmations_controller_spec.rb
@@ -82,4 +82,23 @@ RSpec.describe UserConfirmationsController, type: :controller do
       expect { get :confirm_email_token, params: {email_token: SecureRandom.hex(20)} }.to raise_error(ActionController::RoutingError)
     end
   end
+
+  describe "POST #confirm_email" do
+    it "confirms user email if email token is valid" do
+      user = FactoryBot.create(:user_with_email_token)
+
+      post :confirm_email, params: {user_confirmation: {email_token: user.email_token}}
+      user.reload
+
+      expect(response.status).to eq(302)
+      expect(user.active?).to eq(true)
+      expect(user.activated_at).to be_within(1.second).of DateTime.now
+    end
+
+    it "returns not found if token is invalid" do
+      expect {
+        post :confirm_email, params: {user_confirmation: {email_token: SecureRandom.hex(20)}}
+      }.to raise_error(ActionController::RoutingError)
+    end
+  end
 end

--- a/spec/controllers/user_confirmations_controller_spec.rb
+++ b/spec/controllers/user_confirmations_controller_spec.rb
@@ -65,15 +65,17 @@ RSpec.describe UserConfirmationsController, type: :controller do
   end
 
   describe "GET #confirm_email_token" do
-    it "activates user account and redirects to email token" do
+    render_views
+
+    it "renders view to confirm user account if token is valid" do
       user = FactoryBot.create(:user, email_token: SecureRandom.hex(20))
 
       get :confirm_email_token, params: {email_token: user.email_token}
       user.reload
 
-      expect(response.status).to eq(302)
-      expect(user.activated_at).to be_within(1.second).of DateTime.now
-      expect(user.active?).to eq(true)
+      expect(response.status).to eq(200)
+      expect(response.body).to include("Confirm my email")
+      expect(user.active?).to eq(false)
     end
 
     it "returns not found if token is invalid" do

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -45,5 +45,9 @@ FactoryBot.define do
     factory :user_with_confirmation_token do
       confirmation_token { SecureRandom.hex(20) }
     end
+
+    factory :user_with_email_token do
+      email_token { SecureRandom.hex(20) }
+    end
   end
 end

--- a/spec/features/user_confirmations_spec.rb
+++ b/spec/features/user_confirmations_spec.rb
@@ -32,7 +32,8 @@ describe "UserConfirmations", type: :feature do
 
       visit "/user_confirmations?confirmation_token=#{user.confirmation_token}"
 
-      expect(page).to have_content("This email has been already confirmed")
+      expect(page).to have_content("Your email has been already confirmed")
+      expect(page).to have_content("Click here to go to the login page")
     end
   end
 end

--- a/spec/jobs/link_discourse_account_job_spec.rb
+++ b/spec/jobs/link_discourse_account_job_spec.rb
@@ -13,29 +13,57 @@ RSpec.describe LinkDiscourseAccountJob, type: :job do
   end
 
   describe "#perform" do
-    it "it sets external_id to the one found on Discourse if user is confirmed" do
-      user = FactoryBot.create(:user, external_id: nil, confirmed_at: DateTime.now)
+    context "existing account" do
+      it "it sets external_id to the one found on Discourse if user is confirmed" do
+        user = FactoryBot.create(:user, external_id: nil, confirmed_at: DateTime.now)
 
-      expect_any_instance_of(DiscourseService).to receive(:find_user_by_email).and_return({"id" => 10})
-      expect_any_instance_of(DiscourseService).not_to receive(:invite_user)
+        expect_any_instance_of(DiscourseService).to receive(:find_user_by_email).and_return({"id" => 10})
+        expect_any_instance_of(DiscourseService).not_to receive(:invite_user)
 
-      perform_enqueued_jobs { LinkDiscourseAccountJob.perform_later(user) }
+        perform_enqueued_jobs { LinkDiscourseAccountJob.perform_later(user) }
 
-      user.reload
-      expect(user.external_id).to eq(10)
+        user.reload
+        expect(user.external_id).to eq(10)
+      end
+
+      it "it send confirmation email if user is on Discourse but not confirmed" do
+        user = FactoryBot.create(:user, external_id: nil)
+
+        expect_any_instance_of(DiscourseService).to receive(:find_user_by_email).and_return({"id" => 10})
+        expect_any_instance_of(DiscourseService).not_to receive(:invite_user)
+        expect(UserMailer).to receive_message_chain(:confirmation_email, :deliver_later)
+
+        perform_enqueued_jobs { LinkDiscourseAccountJob.perform_later(user) }
+
+        user.reload
+        expect(user.external_id).to be_nil
+      end
     end
 
-    it "it send confirmation email if user is on Discourse but not confirmed" do
-      user = FactoryBot.create(:user, external_id: nil)
+    context "new account" do
+      it "creates a discourse account and updates the user record" do
+        user = FactoryBot.create(:user, external_id: nil)
+        response = {
+          "success" => true,
+          "active" => true,
+          "email_token" => "15fa6c1c626cb97ccf18e5abd537260e",
+          "message" =>
+            "Your account is activated and ready to use.",
+          "user_id" => 9,
+          "username" => "orlando"
+        }
 
-      expect_any_instance_of(DiscourseService).to receive(:find_user_by_email).and_return({"id" => 10})
-      expect_any_instance_of(DiscourseService).not_to receive(:invite_user)
-      expect(UserMailer).to receive_message_chain(:confirmation_email, :deliver_later)
+        expect_any_instance_of(DiscourseService).to receive(:find_user_by_email).and_return(nil)
+        expect_any_instance_of(DiscourseService).to receive(:create_user).and_return(response)
+        expect(UserMailer).to receive_message_chain(:welcome_email, :deliver_later)
 
-      perform_enqueued_jobs { LinkDiscourseAccountJob.perform_later(user) }
+        perform_enqueued_jobs { LinkDiscourseAccountJob.perform_later(user) }
+        user.reload
 
-      user.reload
-      expect(user.external_id).to be_nil
+        expect(user.external_id).to eq(9)
+        expect(user.username).to eq("orlando")
+        expect(user.email_token).to be_present
+      end
     end
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -91,5 +91,14 @@ RSpec.describe User, type: :model do
       expect(user.email).to eq(email)
       expect(user.external_id).to eq(external_id)
     end
+
+    it "before validation normalizes attributes" do
+      user = FactoryBot.build(:user, email: "ExAmPlE@TeSt.com")
+      expect(user.email).to eq("ExAmPlE@TeSt.com")
+
+      user.valid?
+
+      expect(user.email).to eq("example@test.com")
+    end
   end
 end

--- a/spec/services/discourse_service_spec.rb
+++ b/spec/services/discourse_service_spec.rb
@@ -117,7 +117,8 @@ RSpec.describe DiscourseService, type: :service do
         "email_token" => "15fa6c1c626cb97ccf18e5abd537260e",
         "message" =>
           "Your account is activated and ready to use.",
-        "user_id" => 9
+        "user_id" => 9,
+        "username" => "orlando"
       }
 
       stub_discourse_request(:post, "users")


### PR DESCRIPTION
**What:** Add email confirmation view to preventing bots from activating accounts

**Why:** Closes https://app.asana.com/0/1168997577035609/1199961202302646. Improve the email confirmation flow.

**How:**

Create a view to confirming email to prevent email crawlers to click on the email confirmation links.
Other small fixes.

**Media:**

![image](https://user-images.githubusercontent.com/849872/108910349-57754680-75eb-11eb-962e-b4dfce56ed2a.png)
![image](https://user-images.githubusercontent.com/849872/108910369-5e03be00-75eb-11eb-8816-53bdb1aa41f4.png)

