### PR TITLE
set confirmation_sent_at and fix confirmed? method

### DIFF
--- a/app/jobs/link_discourse_account_job.rb
+++ b/app/jobs/link_discourse_account_job.rb
@@ -44,6 +44,7 @@ class LinkDiscourseAccountJob < ApplicationJob
       logger.info("Discourse account created. discourse_id: #{response["user_id"]} user_id: #{user.id}")
     end
 
+    user.confirmation_sent_at = DateTime.now
     user.save!
 
     user.send_welcome_email

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -96,7 +96,7 @@ class User < ApplicationRecord
   end
 
   def confirmed?
-    external_id.present? || confirmed_at.present?
+    confirmed_at.present?
   end
 
   def pending_plan_change


### PR DESCRIPTION
**What:** set confirmation_sent_at and fix confirmed? method

**Why:** Fixes an issue where users without a confirmed email saw a message telling them their email is confirmed already

**How:**

- fix confirmed? method to use only `confirmed_at` for the boolean check
- set confirmed_sent_at when sending the welcome email