### PR TITLE
Remove has_many relationship with subscriptions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,6 +24,7 @@ gem 'ffi', '~> 1.9', '>= 1.9.25'
 gem 'rack-cors', '1.1.1'
 gem 'discourse_api', '0.45.0'
 gem 'data_migrate', '7.0.0'
+gem 'paper_trail', '12.0.0'
 
 # Validations
 gem 'validate_url', '1.0.13'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -231,6 +231,9 @@ GEM
     notiffany (0.1.3)
       nenv (~> 0.1)
       shellany (~> 0.0)
+    paper_trail (12.0.0)
+      activerecord (>= 5.2)
+      request_store (~> 1.1)
     parallel (1.20.1)
     parser (3.0.0.0)
       ast (~> 2.4.1)
@@ -303,6 +306,8 @@ GEM
     redis-namespace (1.8.1)
       redis (>= 3.0.4)
     regexp_parser (1.8.2)
+    request_store (1.5.0)
+      rack (>= 1.4)
     reverse_markdown (2.0.0)
       nokogiri
     rexml (3.2.5)
@@ -486,6 +491,7 @@ DEPENDENCIES
   jwt (~> 2.2.1)
   listen (>= 3.0.5, < 3.6)
   mini_racer
+  paper_trail (= 12.0.0)
   pg (>= 0.18, < 2.0)
   premailer-rails (= 1.11.1)
   pry-byebug (~> 3.9.0)

--- a/app/controllers/memberships_controller.rb
+++ b/app/controllers/memberships_controller.rb
@@ -93,7 +93,7 @@ class MembershipsController < HubController
   private
 
   def set_membership
-    @membership = current_user.subscriptions.last
+    @membership = current_user.subscription
   end
 
   def update_card_params

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -8,7 +8,7 @@ class UserMailer < ApplicationMailer
 
   def welcome_email(user:)
     @user = user
-    @subscription = user.active_subscription
+    @subscription = user.subscription
     email = @user.email
 
     mail to: email, from: ENV["MAIL_FROM"]

--- a/app/models/current_user.rb
+++ b/app/models/current_user.rb
@@ -36,10 +36,9 @@ class CurrentUser < Delegator
 
   def as_json(options = {})
     options[:only] = [:id, :name, :email, :external_id]
-    options[:methods] = [:active_subscription, :confirmed?]
+    options[:methods] = [:subscription, :confirmed?]
     json = super(options)
     json["confirmed"] = json.delete("confirmed?")
-    json["subscription"] = json.delete("active_subscription")
 
     json
   end

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -22,6 +22,10 @@ class Subscription < ApplicationRecord
   # TODO: remove this after we run the migrations correctly on production and we can delete the `active :boolean` column
   self.ignored_columns = ["active"]
 
+  has_paper_trail(
+    only: [:amount, :status]
+  )
+
   FAILED_CHARGE_COUNT_BEFORE_DISABLE = 5
   SUBSCRIPTION_PERIOD = 1.month
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -38,7 +38,7 @@ class User < ApplicationRecord
   ].freeze
 
   has_one :user_profile, autosave: true
-  has_many :subscriptions
+  has_one :subscription
   has_many :donations
 
   validates :email, presence: true, 'valid_email_2/email': true, uniqueness: {case_sensitive: false}
@@ -102,10 +102,6 @@ class User < ApplicationRecord
 
   def pending_plan_change
     @pending_plan_change ||= user_plan_changes.where(status: :pending).first
-  end
-
-  def active_subscription
-    @active_subscription ||= subscriptions.where(status: :active).last
   end
 
   def find_stripe_customer

--- a/cypress/integration/member-membership.spec.js
+++ b/cypress/integration/member-membership.spec.js
@@ -138,4 +138,34 @@ describe('Member Membership', () => {
       })
     })
   })
+
+  describe('Resume membership', () => {
+    it('activates the membership', () => {
+      cy.appFactories([
+        [
+          'create',
+          'user_with_subscription',
+          {
+            email: 'example@debtcollective.org',
+            subscription_status: 'paused'
+          }
+        ]
+      ]).then(async records => {
+        const [user] = records
+        cy.forceLogin({ email: user.email }).then(result => {
+          cy.visit('/membership')
+
+          cy.get('a')
+            .contains('Update status', { matchCase: false })
+            .click()
+          cy.contains('Resume your membership')
+
+          cy.on('window:confirm', () => true)
+          cy.get('input[type="submit"][value="Resume membership"]').click()
+
+          cy.contains('Your membership is now active')
+        })
+      })
+    })
+  })
 })

--- a/db/migrate/20210522002127_create_versions.rb
+++ b/db/migrate/20210522002127_create_versions.rb
@@ -1,0 +1,27 @@
+class CreateVersions < ActiveRecord::Migration[6.1]
+  def change
+    create_table :versions do |t|
+      t.string :item_type, {null: false}
+      t.bigint :item_id, null: false
+      t.string :event, null: false
+      t.string :whodunnit
+      t.jsonb :object
+
+      # Known issue in MySQL: fractional second precision
+      # -------------------------------------------------
+      #
+      # MySQL timestamp columns do not support fractional seconds unless
+      # defined with "fractional seconds precision". MySQL users should manually
+      # add fractional seconds precision to this migration, specifically, to
+      # the `created_at` column.
+      # (https://dev.mysql.com/doc/refman/5.6/en/fractional-seconds.html)
+      #
+      # MySQL users should also upgrade to at least rails 4.2, which is the first
+      # version of ActiveRecord with support for fractional seconds in MySQL.
+      # (https://github.com/rails/rails/pull/14359)
+      #
+      t.datetime :created_at
+    end
+    add_index :versions, %i[item_type item_id]
+  end
+end

--- a/db/migrate/20210522002128_add_object_changes_to_versions.rb
+++ b/db/migrate/20210522002128_add_object_changes_to_versions.rb
@@ -1,0 +1,5 @@
+class AddObjectChangesToVersions < ActiveRecord::Migration[6.1]
+  def change
+    add_column :versions, :object_changes, :jsonb
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_05_19_195922) do
+ActiveRecord::Schema.define(version: 2021_05_22_002128) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -150,6 +150,17 @@ ActiveRecord::Schema.define(version: 2021_05_19_195922) do
     t.string "email_token"
     t.inet "registration_ip_address"
     t.index ["email"], name: "index_users_on_email", unique: true
+  end
+
+  create_table "versions", force: :cascade do |t|
+    t.string "item_type", null: false
+    t.bigint "item_id", null: false
+    t.string "event", null: false
+    t.string "whodunnit"
+    t.jsonb "object"
+    t.datetime "created_at"
+    t.jsonb "object_changes"
+    t.index ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id"
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"

--- a/spec/controllers/memberships_controller_spec.rb
+++ b/spec/controllers/memberships_controller_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe MembershipsController, type: :controller do
   describe "PUT #update_amount" do
     it "with valid amount it updates the membership amount" do
       user = FactoryBot.create(:user_with_subscription, email: "example@debtcollective.org")
-      subscription = user.active_subscription
+      subscription = user.subscription
 
       allow_any_instance_of(SessionProvider).to receive(:current_user).and_return(CurrentUser.new(user))
 
@@ -19,7 +19,7 @@ RSpec.describe MembershipsController, type: :controller do
 
     it "it returns an error with an amount less than 5 USD" do
       user = FactoryBot.create(:user_with_subscription, email: "example@debtcollective.org")
-      subscription = user.active_subscription
+      subscription = user.subscription
 
       allow_any_instance_of(SessionProvider).to receive(:current_user).and_return(CurrentUser.new(user))
 
@@ -45,7 +45,7 @@ RSpec.describe MembershipsController, type: :controller do
         user = FactoryBot.create(:user_with_subscription, email: "example@debtcollective.org")
         stripe_customer = Stripe::Customer.create(email: user.email)
         user.update(stripe_id: stripe_customer.id)
-        subscription = user.active_subscription
+        subscription = user.subscription
         allow_any_instance_of(SessionProvider).to receive(:current_user).and_return(CurrentUser.new(user))
 
         params = {
@@ -73,7 +73,7 @@ RSpec.describe MembershipsController, type: :controller do
   describe "PUT #pause" do
     it "it pauses the membership" do
       user = FactoryBot.create(:user_with_subscription, email: "example@debtcollective.org")
-      subscription = user.active_subscription
+      subscription = user.subscription
 
       allow_any_instance_of(SessionProvider).to receive(:current_user).and_return(CurrentUser.new(user))
       expect(subscription.paused?).to eq(false)

--- a/spec/controllers/memberships_controller_spec.rb
+++ b/spec/controllers/memberships_controller_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe MembershipsController, type: :controller do
   describe "PUT #resume" do
     it "it activates the membership" do
       user = FactoryBot.create(:user_with_subscription, email: "example@debtcollective.org")
-      subscription = user.active_subscription
+      subscription = user.subscription
 
       allow_any_instance_of(SessionProvider).to receive(:current_user).and_return(CurrentUser.new(user))
       expect(subscription.paused?).to eq(false)

--- a/spec/controllers/subscriptions_controller_spec.rb
+++ b/spec/controllers/subscriptions_controller_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe SubscriptionsController, type: :controller do
         expect { post :create, params: params, session: {} }.to change { Subscription.count }.by(1)
 
         user = User.last
-        subscription = user.active_subscription
+        subscription = user.subscription
         donation = subscription.donations.last
 
         expect(subscription.active?).to eq(true)
@@ -56,7 +56,7 @@ RSpec.describe SubscriptionsController, type: :controller do
         expect { post :create, params: params, session: {} }.to change { Subscription.count }.by(1)
 
         user = User.last
-        subscription = user.active_subscription
+        subscription = user.subscription
         donation = subscription.donations.last
 
         expect(subscription.active?).to eq(true)
@@ -107,7 +107,7 @@ RSpec.describe SubscriptionsController, type: :controller do
 
         user = User.find_by(email: "newuser@example.com")
         donation = user.donations.last
-        subscription = user.active_subscription
+        subscription = user.subscription
 
         parsed_body = JSON.parse(response.body)
         expect(response).to have_http_status(200)

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe UsersController, type: :controller do
 
       expect(response.status).to eq(200)
       expect(json["id"]).to eq(user.id)
-      expect(json["subscription"]["id"]).to eq(user.active_subscription.id)
+      expect(json["subscription"]["id"]).to eq(user.subscription.id)
     end
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -35,8 +35,12 @@ FactoryBot.define do
     email { Faker::Internet.email }
 
     factory :user_with_subscription do
-      after(:create) do |user|
-        FactoryBot.create(:subscription_with_donation, user: user)
+      transient do
+        subscription_status { :active }
+      end
+
+      after(:create) do |user, evaluator|
+        FactoryBot.create(:subscription_with_donation, user: user, status: evaluator.subscription_status)
       end
     end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe User, type: :model do
   end
 
   describe "associations" do
-    it { is_expected.to have_many(:subscriptions) }
+    it { is_expected.to have_one(:subscription) }
     it { is_expected.to have_many(:donations) }
   end
 


### PR DESCRIPTION
**What:** Remove has_many relationship with subscriptions

**Why:** Closes https://app.asana.com/0/1168997577035609/1200366454270521

**How:**

- Add paper_trail gem to track changes in status or amount on a subscription
- change the code to fit the has_one relationship change