### PR TITLE
dev(subscription): migrate metadata

### DIFF
--- a/db/data/20210530161632_add_metadata_to_subscriptions.rb
+++ b/db/data/20210530161632_add_metadata_to_subscriptions.rb
@@ -1,0 +1,26 @@
+class AddMetadataToSubscriptions < ActiveRecord::Migration[6.1]
+  def up
+    Subscription.find_each do |subscription|
+      user = subscription.user
+      donation = subscription.donations.last
+
+      next unless donation
+
+      subscription.metadata = {
+        payment_provider: "stripe",
+        payment_method: {
+          type: "card",
+          last4: donation.charge_data&.[]("source")&.[]("last4"),
+          card_id: donation.charge_data&.[]("source")&.[]("id"),
+          customer_id: user.stripe_id
+        }
+      }
+
+      subscription.save
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/data_schema.rb
+++ b/db/data_schema.rb
@@ -1,2 +1,2 @@
 # encoding: UTF-8
-DataMigrate::Data.define(version: 20210519195970)
+DataMigrate::Data.define(version: 20210530161632)


### PR DESCRIPTION
**What:** migrate subscription metadata

**Why:** to have the card details stored in the subscription metadata field instead of the donation

**How:**

- create a data migration to move the data from donation to subscription